### PR TITLE
GML-2072 Better Trace Log and related UI

### DIFF
--- a/common/llm_services/base_llm.py
+++ b/common/llm_services/base_llm.py
@@ -23,6 +23,32 @@ from langchain_community.callbacks.manager import get_openai_callback
 logger = logging.getLogger(__name__)
 
 
+# Per-request collector for LLM usage so callers (e.g. agent trace logs) can
+# aggregate token usage without breaking the existing return signatures.
+# It's a context-local list the agent resets before each node executes.
+import contextvars as _contextvars
+
+_usage_collector: _contextvars.ContextVar = _contextvars.ContextVar(
+    "llm_usage_collector", default=None
+)
+
+
+def start_usage_collection():
+    """Begin collecting LLM usage for the current context (per node)."""
+    _usage_collector.set([])
+
+
+def get_collected_usage():
+    """Return the usage entries collected since the last start (or None)."""
+    return _usage_collector.get()
+
+
+def _record_usage(caller_name: str, usage_data: dict):
+    bucket = _usage_collector.get()
+    if bucket is not None:
+        bucket.append({"caller_name": caller_name, **usage_data})
+
+
 class LLM_Model:
     """Base LLM_Model Class
 
@@ -95,6 +121,7 @@ class LLM_Model:
             usage_data["total_tokens"] = cb.total_tokens
             usage_data["cost"] = cb.total_cost
             logger.info(f"{caller_name} usage: {usage_data}")
+            _record_usage(caller_name, usage_data)
 
         raw_text = raw_output.content if hasattr(raw_output, "content") else str(raw_output)
 
@@ -131,6 +158,7 @@ class LLM_Model:
             usage_data["total_tokens"] = cb.total_tokens
             usage_data["cost"] = cb.total_cost
             logger.info(f"{caller_name} usage: {usage_data}")
+            _record_usage(caller_name, usage_data)
 
         raw_text = raw_output.content if hasattr(raw_output, "content") else str(raw_output)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       USE_CYPHER: "true"
     volumes:
       - ./configs/:/code/configs
+      - ./trace_logs/:/code/trace_logs
 
   graphrag-ecc:
     image: tigergraph/graphrag-ecc:latest

--- a/docs/tutorials/configs/nginx.conf
+++ b/docs/tutorials/configs/nginx.conf
@@ -29,6 +29,14 @@ server {
     proxy_pass http://graphrag-ui:3000/;
   }
 
+  location /trace {
+    proxy_pass http://graphrag-ui:3000;
+  }
+
+  location /trace/ {
+    proxy_pass http://graphrag-ui:3000;
+  }
+
   location ~^/ui/.*/chat$ {
     proxy_pass http://graphrag:8000;
     proxy_http_version 1.1;

--- a/graphrag-ui/src/actions/ActionProvider.tsx
+++ b/graphrag-ui/src/actions/ActionProvider.tsx
@@ -1,4 +1,4 @@
-import React, {useState, useCallback, useEffect, useContext} from 'react';
+import React, {useState, useRef, useCallback, useEffect, useContext} from 'react';
 import {createClientMessage} from 'react-chatbot-kit';
 import useWebSocket, {ReadyState} from 'react-use-websocket';
 import Loader from '../components/Loader';
@@ -81,6 +81,7 @@ const ActionProvider: React.FC<ActionProviderProps> = ({
 }) => {
   const selectedGraph = useContext(SelectedGraphContext);
   const selectedRagPattern = useContext(RagPatternContext);
+  const lastUserQueryRef = useRef<string>("");
   const WS_URL = "/ui/" + selectedGraph + "/chat" + "?rag_pattern=" + selectedRagPattern;
   const [messageHistory, setMessageHistory] = useState<MessageEvent<Message>[]>(
     [],
@@ -205,6 +206,7 @@ const ActionProvider: React.FC<ActionProviderProps> = ({
   };
 
   const defaultQuestions = (msg: string) => {
+    lastUserQueryRef.current = msg;
     const clientMessage = createClientMessage(msg, {
       delay: 300,
     });
@@ -213,6 +215,7 @@ const ActionProvider: React.FC<ActionProviderProps> = ({
   };
 
   const queryGraphragWs = (msg) => {
+    lastUserQueryRef.current = msg;
     const queryGraphragWsTest = (msg: string) => {
       sendMessage(msg);
     };
@@ -268,6 +271,9 @@ const ActionProvider: React.FC<ActionProviderProps> = ({
           // Don't dispatch refresh event here - refresh happens when user sends the question
           return; // Don't create a bot message for conversation ID
         }
+
+        // Attach the user query so the trace page can display it
+        messageData.userQuery = lastUserQueryRef.current;
 
         // Handle regular bot messages
         const botMessage = createChatBotMessage(messageData);

--- a/graphrag-ui/src/components/CustomChatMessage.tsx
+++ b/graphrag-ui/src/components/CustomChatMessage.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/components/ui/dialog"
 import { ImEnlarge2 } from "react-icons/im";
 import { IoIosCloseCircleOutline } from "react-icons/io";
+import { LuActivity } from "react-icons/lu";
+import { useNavigate } from "react-router-dom";
 import { Interactions } from "./Interact";
 import { KnowledgeGraphPro } from "./graphs/KnowledgeGraphPro";
 import { KnowledgeTablPro } from "./tables/KnowledgeTablePro";
@@ -127,6 +129,7 @@ const AuthenticatedImage: FC<{ src: string; alt: string }> = ({ src, alt }) => {
 export const CustomChatMessage: FC<IChatbotMessageProps> = ({
   message,
 }) => {
+  const navigate = useNavigate();
   const [showResult, setShowResult] = useState<boolean>(false);
   const [showGraphVis, setShowGraphVis] = useState<boolean>(false);
   const [showTableVis, setShowTableVis] = useState<boolean>(false);
@@ -191,6 +194,17 @@ export const CustomChatMessage: FC<IChatbotMessageProps> = ({
               showTable={handleShowTable}
               showGraph={handleShowGraph}
             />
+            {(message.response_type !== "progress" && (message.query_sources?.result || message.query_sources?.reasoning)) && (
+              <button
+                className="flex items-center gap-1.5 mt-2 text-blue-600 dark:text-blue-400 text-sm hover:underline cursor-pointer"
+                onClick={() => {
+                  navigate("/trace", { state: { message, userQuery: message.userQuery || "" } });
+                }}
+              >
+                <LuActivity className="w-4 h-4" />
+                View Trace
+              </button>
+            )}
           </div>
 
           {showGraphVis ? (

--- a/graphrag-ui/src/components/CustomChatMessage.tsx
+++ b/graphrag-ui/src/components/CustomChatMessage.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/ui/dialog"
 import { ImEnlarge2 } from "react-icons/im";
 import { IoIosCloseCircleOutline } from "react-icons/io";
-import { LuActivity } from "react-icons/lu";
 import { useNavigate } from "react-router-dom";
 import { Interactions } from "./Interact";
 import { KnowledgeGraphPro } from "./graphs/KnowledgeGraphPro";
@@ -193,18 +192,12 @@ export const CustomChatMessage: FC<IChatbotMessageProps> = ({
               showExplain={handleShowExplain}
               showTable={handleShowTable}
               showGraph={handleShowGraph}
+              onViewTrace={() => {
+                navigate(`/trace/${message.messageId || message.message_id || ""}`, {
+                  state: { message, userQuery: message.userQuery || "" },
+                });
+              }}
             />
-            {(message.response_type !== "progress" && (message.query_sources?.result || message.query_sources?.reasoning)) && (
-              <button
-                className="flex items-center gap-1.5 mt-2 text-blue-600 dark:text-blue-400 text-sm hover:underline cursor-pointer"
-                onClick={() => {
-                  navigate("/trace", { state: { message, userQuery: message.userQuery || "" } });
-                }}
-              >
-                <LuActivity className="w-4 h-4" />
-                View Trace
-              </button>
-            )}
           </div>
 
           {showGraphVis ? (

--- a/graphrag-ui/src/components/CustomChatMessage.tsx
+++ b/graphrag-ui/src/components/CustomChatMessage.tsx
@@ -192,7 +192,9 @@ export const CustomChatMessage: FC<IChatbotMessageProps> = ({
               showGraph={handleShowGraph}
               onViewTrace={() => {
                 const messageId = message.messageId || message.message_id || "";
-                // No noopener — browser copies sessionStorage to the new tab automatically.
+                // Store message in sessionStorage so the new tab reads it directly
+                // without needing an authenticated API fetch (which triggers browser auth dialog).
+                sessionStorage.setItem(`trace_msg_${messageId}`, JSON.stringify(message));
                 window.open(`/trace/${messageId}`, "_blank");
               }}
             />

--- a/graphrag-ui/src/components/CustomChatMessage.tsx
+++ b/graphrag-ui/src/components/CustomChatMessage.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/ui/dialog"
 import { ImEnlarge2 } from "react-icons/im";
 import { IoIosCloseCircleOutline } from "react-icons/io";
-import { useNavigate } from "react-router-dom";
 import { Interactions } from "./Interact";
 import { KnowledgeGraphPro } from "./graphs/KnowledgeGraphPro";
 import { KnowledgeTablPro } from "./tables/KnowledgeTablePro";
@@ -128,7 +127,6 @@ const AuthenticatedImage: FC<{ src: string; alt: string }> = ({ src, alt }) => {
 export const CustomChatMessage: FC<IChatbotMessageProps> = ({
   message,
 }) => {
-  const navigate = useNavigate();
   const [showResult, setShowResult] = useState<boolean>(false);
   const [showGraphVis, setShowGraphVis] = useState<boolean>(false);
   const [showTableVis, setShowTableVis] = useState<boolean>(false);
@@ -193,9 +191,9 @@ export const CustomChatMessage: FC<IChatbotMessageProps> = ({
               showTable={handleShowTable}
               showGraph={handleShowGraph}
               onViewTrace={() => {
-                navigate(`/trace/${message.messageId || message.message_id || ""}`, {
-                  state: { message, userQuery: message.userQuery || "" },
-                });
+                const messageId = message.messageId || message.message_id || "";
+                // No noopener — browser copies sessionStorage to the new tab automatically.
+                window.open(`/trace/${messageId}`, "_blank");
               }}
             />
           </div>

--- a/graphrag-ui/src/components/Interact.tsx
+++ b/graphrag-ui/src/components/Interact.tsx
@@ -10,7 +10,8 @@ import { PiArrowsCounterClockwiseFill } from "react-icons/pi";
 import { Feedback, Message } from "@/actions/ActionProvider";
 import { PiGraph } from "react-icons/pi";
 import { FaTable } from "react-icons/fa";
-import { LuInfo } from "react-icons/lu";
+import { LuInfo, LuActivity } from "react-icons/lu";
+import { useRoles } from "@/hooks/useRoles";
 const GRAPHRAG_URL = "";
 
 interface Interactions {
@@ -18,6 +19,7 @@ interface Interactions {
   showExplain: () => boolean;
   showTable: () => boolean;
   showGraph: () => boolean;
+  onViewTrace?: () => void;
 }
 
 export const Interactions: FC<Interactions> = ({ 
@@ -25,8 +27,11 @@ export const Interactions: FC<Interactions> = ({
   showExplain,
   showTable,
   showGraph,
+  onViewTrace,
 }: Interactions) => {
   const [feedback, setFeedback] = useState(Feedback.NoFeedback);
+  const { isSuperuser, isGlobalDesigner, isGraphAdmin } = useRoles();
+  const canViewTrace = isSuperuser || isGlobalDesigner || isGraphAdmin;
 
   const sendFeedback = async (action: Feedback, message: Message) => {
     const creds = sessionStorage.getItem("creds");
@@ -90,13 +95,23 @@ export const Interactions: FC<Interactions> = ({
             <PiArrowsCounterClockwiseFill className="text-[15px]" />
           </div> */}
 
-          <div
-            className="w-auto h-[28px] bg-shadeA flex items-center justify-center rounded-sm mr-1 px-2 cursor-pointer"
-            onClick={() => showExplain()}
-          >
-            <LuInfo className="text-[15px] mr-1" />
-            <span className="text-xs">Explain</span>
-          </div>
+          {canViewTrace ? (
+            <div
+              className="w-auto h-[28px] bg-shadeA flex items-center justify-center rounded-sm mr-1 px-2 cursor-pointer"
+              onClick={() => onViewTrace?.()}
+            >
+              <LuActivity className="text-[15px] mr-1" />
+              <span className="text-xs">View Trace</span>
+            </div>
+          ) : (
+            <div
+              className="w-auto h-[28px] bg-shadeA flex items-center justify-center rounded-sm mr-1 px-2 cursor-pointer"
+              onClick={() => showExplain()}
+            >
+              <LuInfo className="text-[15px] mr-1" />
+              <span className="text-xs">Explain</span>
+            </div>
+          )}
 
           <div
             className={`w-[28px] h-[28px] bg-shadeA flex items-center justify-center rounded-sm ml-5 mr-1 ${

--- a/graphrag-ui/src/main.tsx
+++ b/graphrag-ui/src/main.tsx
@@ -4,6 +4,7 @@ import "./index.css";
 import { Outlet, RouterProvider, createBrowserRouter, Navigate } from "react-router-dom";
 import Chat from "./pages/Chat";
 import ChatDialog from "./pages/ChatDialog.tsx";
+import TraceLogs from "./pages/TraceLogs.tsx";
 import SetupLayout from "./pages/setup/SetupLayout.tsx";
 import KGAdmin from "./pages/setup/KGAdmin.tsx";
 import IngestGraph from "./pages/setup/IngestGraph.tsx";
@@ -55,6 +56,10 @@ const router = createBrowserRouter([
       {
         path: "/preferences",
         element: <RequireAuth><ChatDialog /></RequireAuth>,
+      },
+      {
+        path: "/trace",
+        element: <RequireAuth><TraceLogs /></RequireAuth>,
       },
       {
         path: "/setup",

--- a/graphrag-ui/src/main.tsx
+++ b/graphrag-ui/src/main.tsx
@@ -58,7 +58,7 @@ const router = createBrowserRouter([
         element: <RequireAuth><ChatDialog /></RequireAuth>,
       },
       {
-        path: "/trace",
+        path: "/trace/:messageId",
         element: <RequireAuth><TraceLogs /></RequireAuth>,
       },
       {

--- a/graphrag-ui/src/main.tsx
+++ b/graphrag-ui/src/main.tsx
@@ -26,6 +26,7 @@ const RequireAuth = ({ children }: { children: any }) => {
   return children;
 };
 
+
 const Layout = () => {
   useIdleTimeout();
   return (

--- a/graphrag-ui/src/pages/TraceLogs.tsx
+++ b/graphrag-ui/src/pages/TraceLogs.tsx
@@ -71,7 +71,6 @@ interface TraceData {
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function formatDuration(seconds: number): string {
-  if (seconds < 1) return `${(seconds * 1000).toFixed(0)}ms`;
   return `${seconds.toFixed(2)}s`;
 }
 
@@ -353,7 +352,7 @@ const LogsPanel: FC<{ trace: TraceData }> = ({ trace }) => {
                 </span>
                 {log.durationMs != null && log.durationMs > 0 && (
                   <span className="text-xs text-emerald-600 dark:text-emerald-400">
-                    ({log.durationMs}ms)
+                    ({formatDuration(log.durationMs / 1000)})
                   </span>
                 )}
               </ExpandableRow>
@@ -383,7 +382,7 @@ const ToolCallExpandable: FC<{ tc: ToolCallEntry }> = ({ tc }) => {
         <div className="flex items-center gap-2 ml-2 shrink-0">
           {tc.durationMs > 0 && (
             <span className="bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 text-xs font-medium px-2 py-0.5 rounded-full">
-              {tc.durationMs}ms
+              {formatDuration(tc.durationMs / 1000)}
             </span>
           )}
           {open ? (
@@ -489,7 +488,7 @@ const TimelinePanel: FC<{ trace: TraceData }> = ({ trace }) => (
         </div>
         <div className="flex flex-col items-start gap-1">
           <span className="bg-blue-600 text-white text-xs font-bold px-3 py-1 rounded-full">
-            {item.durationMs}ms
+            {formatDuration(item.durationMs / 1000)}
           </span>
           <span className="text-sm text-muted-foreground">{item.name}</span>
         </div>

--- a/graphrag-ui/src/pages/TraceLogs.tsx
+++ b/graphrag-ui/src/pages/TraceLogs.tsx
@@ -266,6 +266,17 @@ function formatNumber(n: number): string {
   return (n || 0).toLocaleString();
 }
 
+function formatCallerNames(calls: { caller_name: string }[]): string {
+  if (!calls || calls.length === 0) return "—";
+  const counts: Record<string, number> = {};
+  calls.forEach((c) => {
+    counts[c.caller_name] = (counts[c.caller_name] || 0) + 1;
+  });
+  return Object.entries(counts)
+    .map(([name, count]) => (count > 1 ? `${name} ×${count}` : name))
+    .join(", ");
+}
+
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
 const StatusBadge: FC<{ status: string }> = ({ status }) => {
@@ -474,12 +485,12 @@ const ToolCallExpandable: FC<{ tc: ToolCallEntry }> = ({ tc }) => {
                   <div className="text-sm font-semibold">{formatCost(tc.usage.cost)}</div>
                 </div>
               </div>
-              {tc.usage.calls && tc.usage.calls.length > 0 && (
-                <div className="mt-2 text-xs text-muted-foreground">
-                  {tc.usage.calls.length} LLM call{tc.usage.calls.length !== 1 ? "s" : ""}:{" "}
-                  {tc.usage.calls.map((c) => c.caller_name).join(", ")}
-                </div>
-              )}
+                {tc.usage.calls && tc.usage.calls.length > 0 && (
+                  <div className="mt-2 text-xs text-muted-foreground">
+                    {tc.usage.calls.length} LLM call{tc.usage.calls.length !== 1 ? "s" : ""}:{" "}
+                    {formatCallerNames(tc.usage.calls)}
+                  </div>
+                )}
             </div>
           )}
           <div>
@@ -687,7 +698,7 @@ const TokenOverviewPanel: FC<{ trace: TraceData }> = ({ trace }) => {
                     </td>
                     <td className="px-4 py-2 text-xs text-muted-foreground">
                       {tc.usage!.calls && tc.usage!.calls.length > 0
-                        ? tc.usage!.calls.map((c) => c.caller_name).join(", ")
+                        ? formatCallerNames(tc.usage!.calls)
                         : "—"}
                     </td>
                   </tr>

--- a/graphrag-ui/src/pages/TraceLogs.tsx
+++ b/graphrag-ui/src/pages/TraceLogs.tsx
@@ -10,6 +10,8 @@ import {
   LuWrench,
   LuBookOpen,
   LuActivity,
+  LuCoins,
+  LuInfo,
 } from "react-icons/lu";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -27,6 +29,17 @@ interface TraceLogEntry {
   step?: number;
 }
 
+interface TokenUsage {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cost: number;
+}
+
+interface LlmCall extends TokenUsage {
+  caller_name: string;
+}
+
 interface ToolCallEntry {
   id: number;
   name: string;
@@ -34,6 +47,7 @@ interface ToolCallEntry {
   durationMs: number;
   input?: string;
   output?: string;
+  usage?: TokenUsage & { calls?: LlmCall[] };
 }
 
 interface CitationEntry {
@@ -65,12 +79,14 @@ interface TraceData {
   toolCalls: ToolCallEntry[];
   citations: CitationEntry[];
   timeline: TimelineStep[];
+  tokenUsage: TokenUsage;
   finalResponse: string;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function formatDuration(seconds: number): string {
+  if (seconds < 0.01) return `${Math.round(seconds * 1000)}ms`;
   return `${seconds.toFixed(2)}s`;
 }
 
@@ -116,8 +132,13 @@ function buildTraceFromMessage(message: any, userQuery?: string): TraceData {
 
   // ── Tool Calls ──────────────────────────────────────────────────────────
   const toolCalls: ToolCallEntry[] = [];
-  const agentSteps: { node: string; duration_s: number; input?: string; output?: string }[] =
-    qs.agent_steps || [];
+  const agentSteps: {
+    node: string;
+    duration_s: number;
+    input?: string;
+    output?: string;
+    usage?: TokenUsage & { calls?: LlmCall[] };
+  }[] = qs.agent_steps || [];
 
   if (agentSteps.length > 0) {
     agentSteps.forEach((step, i: number) => {
@@ -128,6 +149,7 @@ function buildTraceFromMessage(message: any, userQuery?: string): TraceData {
         durationMs: Math.round(step.duration_s * 1000),
         input: safeJson(step.input),
         output: safeJson(step.output),
+        usage: step.usage,
       });
     });
   }
@@ -197,6 +219,22 @@ function buildTraceFromMessage(message: any, userQuery?: string): TraceData {
   const llmThinking = Math.max(0, totalResponseTime - totalToolSec);
   const endTime = new Date(now.getTime() + totalResponseTime * 1000);
 
+  // ── Token usage totals ─────────────────────────────────────────────────
+  const serverTotal = qs.token_usage as TokenUsage | undefined;
+  const tokenUsage: TokenUsage = serverTotal || agentSteps.reduce(
+    (acc, s) => {
+      const u = s.usage;
+      if (!u) return acc;
+      return {
+        input_tokens: acc.input_tokens + (u.input_tokens || 0),
+        output_tokens: acc.output_tokens + (u.output_tokens || 0),
+        total_tokens: acc.total_tokens + (u.total_tokens || 0),
+        cost: acc.cost + (u.cost || 0),
+      };
+    },
+    { input_tokens: 0, output_tokens: 0, total_tokens: 0, cost: 0 } as TokenUsage
+  );
+
   return {
     originalQuery: query,
     conversationContext: [`user: ${query}`],
@@ -213,8 +251,19 @@ function buildTraceFromMessage(message: any, userQuery?: string): TraceData {
     toolCalls,
     citations,
     timeline,
+    tokenUsage,
     finalResponse: message?.content || "",
   };
+}
+
+function formatCost(cost: number): string {
+  if (!cost) return "$0.00";
+  if (cost < 0.01) return `$${cost.toFixed(6)}`;
+  return `$${cost.toFixed(4)}`;
+}
+
+function formatNumber(n: number): string {
+  return (n || 0).toLocaleString();
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
@@ -380,6 +429,14 @@ const ToolCallExpandable: FC<{ tc: ToolCallEntry }> = ({ tc }) => {
           <span className="text-xs text-muted-foreground">{tc.timestamp}</span>
         </div>
         <div className="flex items-center gap-2 ml-2 shrink-0">
+          {tc.usage && tc.usage.total_tokens > 0 && (
+            <span
+              className="bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300 text-xs font-medium px-2 py-0.5 rounded-full"
+              title={`Input ${tc.usage.input_tokens} / Output ${tc.usage.output_tokens} / Cost ${formatCost(tc.usage.cost)}`}
+            >
+              {formatNumber(tc.usage.total_tokens)} tokens
+            </span>
+          )}
           {tc.durationMs > 0 && (
             <span className="bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 text-xs font-medium px-2 py-0.5 rounded-full">
               {formatDuration(tc.durationMs / 1000)}
@@ -394,6 +451,37 @@ const ToolCallExpandable: FC<{ tc: ToolCallEntry }> = ({ tc }) => {
       </div>
       {open && (
         <div className="px-4 pb-4 space-y-3">
+          {tc.usage && tc.usage.total_tokens > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+                LLM Usage
+              </p>
+              <div className="grid grid-cols-4 gap-2">
+                <div className="bg-muted rounded-md p-2">
+                  <div className="text-[10px] text-muted-foreground uppercase">Input</div>
+                  <div className="text-sm font-semibold">{formatNumber(tc.usage.input_tokens)}</div>
+                </div>
+                <div className="bg-muted rounded-md p-2">
+                  <div className="text-[10px] text-muted-foreground uppercase">Output</div>
+                  <div className="text-sm font-semibold">{formatNumber(tc.usage.output_tokens)}</div>
+                </div>
+                <div className="bg-muted rounded-md p-2">
+                  <div className="text-[10px] text-muted-foreground uppercase">Total</div>
+                  <div className="text-sm font-semibold">{formatNumber(tc.usage.total_tokens)}</div>
+                </div>
+                <div className="bg-muted rounded-md p-2">
+                  <div className="text-[10px] text-muted-foreground uppercase">Cost</div>
+                  <div className="text-sm font-semibold">{formatCost(tc.usage.cost)}</div>
+                </div>
+              </div>
+              {tc.usage.calls && tc.usage.calls.length > 0 && (
+                <div className="mt-2 text-xs text-muted-foreground">
+                  {tc.usage.calls.length} LLM call{tc.usage.calls.length !== 1 ? "s" : ""}:{" "}
+                  {tc.usage.calls.map((c) => c.caller_name).join(", ")}
+                </div>
+              )}
+            </div>
+          )}
           <div>
             <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1">
               Input
@@ -497,6 +585,142 @@ const TimelinePanel: FC<{ trace: TraceData }> = ({ trace }) => (
   </div>
 );
 
+const TokenOverviewPanel: FC<{ trace: TraceData }> = ({ trace }) => {
+  const usage = trace.tokenUsage;
+  const nodesWithUsage = trace.toolCalls.filter(
+    (tc) => tc.usage && tc.usage.total_tokens > 0
+  );
+
+  return (
+    <div className="space-y-5">
+      {/* Totals */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <div className="bg-card border border-border rounded-lg p-4">
+          <div className="text-xs text-muted-foreground uppercase tracking-wide">
+            Input Tokens
+          </div>
+          <div className="text-2xl font-bold text-blue-600 dark:text-blue-400 mt-1">
+            {formatNumber(usage.input_tokens)}
+          </div>
+        </div>
+        <div className="bg-card border border-border rounded-lg p-4">
+          <div className="text-xs text-muted-foreground uppercase tracking-wide">
+            Output Tokens
+          </div>
+          <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400 mt-1">
+            {formatNumber(usage.output_tokens)}
+          </div>
+        </div>
+        <div className="bg-card border border-border rounded-lg p-4">
+          <div className="text-xs text-muted-foreground uppercase tracking-wide">
+            Total Tokens
+          </div>
+          <div className="text-2xl font-bold text-purple-600 dark:text-purple-400 mt-1">
+            {formatNumber(usage.total_tokens)}
+          </div>
+        </div>
+        <div className="bg-card border border-border rounded-lg p-4">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground uppercase tracking-wide">
+            Est. Cost
+            <span className="relative group inline-flex">
+              <LuInfo className="w-3.5 h-3.5 cursor-help text-muted-foreground hover:text-foreground transition-colors" />
+              <span className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-64 rounded-lg bg-popover border border-border text-popover-foreground text-xs font-normal normal-case tracking-normal shadow-lg px-3 py-2 opacity-0 group-hover:opacity-100 transition-opacity duration-150 z-50 leading-relaxed">
+                Cost is estimated based on the model's published per-token pricing. Actual billing may differ.
+                <span className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-border" />
+              </span>
+            </span>
+          </div>
+          <div className="text-2xl font-bold text-amber-600 dark:text-amber-400 mt-1">
+            {formatCost(usage.cost)}
+          </div>
+          <div className="text-[10px] text-muted-foreground mt-0.5">estimated</div>
+        </div>
+      </div>
+
+      {/* Per-node breakdown */}
+      <div className="bg-card border border-border rounded-lg overflow-hidden">
+        <div className="px-4 py-3 border-b border-border">
+          <h3 className="text-sm font-semibold">Usage by Node</h3>
+        </div>
+        {nodesWithUsage.length === 0 ? (
+          <p className="px-4 py-6 text-sm text-muted-foreground text-center">
+            No LLM usage recorded for this trace.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-xs text-muted-foreground uppercase">
+                <tr>
+                  <th className="px-4 py-2 text-left font-medium">Node</th>
+                  <th className="px-4 py-2 text-right font-medium">Input</th>
+                  <th className="px-4 py-2 text-right font-medium">Output</th>
+                  <th className="px-4 py-2 text-right font-medium">Total</th>
+                  <th className="px-4 py-2 text-right font-medium">
+                    <span className="inline-flex items-center justify-end gap-1.5">
+                      Est. Cost
+                      <span className="relative group inline-flex">
+                        <LuInfo className="w-3.5 h-3.5 cursor-help text-muted-foreground hover:text-foreground transition-colors" />
+                        <span className="pointer-events-none absolute bottom-full right-0 mb-2 w-56 rounded-lg bg-popover border border-border text-popover-foreground text-xs font-normal normal-case tracking-normal shadow-lg px-3 py-2 opacity-0 group-hover:opacity-100 transition-opacity duration-150 z-50 leading-relaxed">
+                          Cost is estimated based on the model's published per-token pricing. Actual billing may differ.
+                        </span>
+                      </span>
+                    </span>
+                  </th>
+                  <th className="px-4 py-2 text-left font-medium">LLM Calls</th>
+                </tr>
+              </thead>
+              <tbody>
+                {nodesWithUsage.map((tc) => (
+                  <tr key={tc.id} className="border-t border-border">
+                    <td className="px-4 py-2 font-medium">{tc.name}</td>
+                    <td className="px-4 py-2 text-right tabular-nums">
+                      {formatNumber(tc.usage!.input_tokens)}
+                    </td>
+                    <td className="px-4 py-2 text-right tabular-nums">
+                      {formatNumber(tc.usage!.output_tokens)}
+                    </td>
+                    <td className="px-4 py-2 text-right tabular-nums font-semibold">
+                      {formatNumber(tc.usage!.total_tokens)}
+                    </td>
+                    <td className="px-4 py-2 text-right tabular-nums">
+                      {formatCost(tc.usage!.cost)}
+                    </td>
+                    <td className="px-4 py-2 text-xs text-muted-foreground">
+                      {tc.usage!.calls && tc.usage!.calls.length > 0
+                        ? tc.usage!.calls.map((c) => c.caller_name).join(", ")
+                        : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+              <tfoot className="bg-muted/40 font-semibold">
+                <tr className="border-t border-border">
+                  <td className="px-4 py-2">Total</td>
+                  <td className="px-4 py-2 text-right tabular-nums">
+                    {formatNumber(usage.input_tokens)}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums">
+                    {formatNumber(usage.output_tokens)}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums">
+                    {formatNumber(usage.total_tokens)}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums">
+                    <span title="Estimated — calculated by LangChain based on model pricing">
+                      {formatCost(usage.cost)}
+                    </span>
+                  </td>
+                  <td />
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
 // ─── Main Page ────────────────────────────────────────────────────────────────
 
 const TraceLogs: FC = () => {
@@ -537,7 +761,13 @@ const TraceLogs: FC = () => {
   );
 
   const handleBack = () => {
-    navigate(-1);
+    // Trace opens in a new tab — closing it returns the user to the chat tab.
+    // If the tab cannot be closed (e.g. opened via direct link), fall back to navigate.
+    if (window.opener || window.history.length <= 1) {
+      window.close();
+    } else {
+      navigate(-1);
+    }
   };
 
   const handleDownload = () => {
@@ -571,7 +801,7 @@ const TraceLogs: FC = () => {
               className="flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:underline mb-1"
             >
               <LuArrowLeft className="w-4 h-4" />
-              Back to Chat
+              Close &amp; Back to Chat
             </button>
             <h1 className="text-xl font-semibold">Trace Logs</h1>
           </div>
@@ -682,6 +912,18 @@ const TraceLogs: FC = () => {
             >
               Timeline
             </TabsTrigger>
+            <TabsTrigger
+              value="tokens"
+              className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 py-2.5"
+            >
+              <LuCoins className="w-4 h-4 mr-1.5" />
+              Token Overview
+              {trace.tokenUsage.total_tokens > 0 && (
+                <span className="ml-1.5 bg-muted text-muted-foreground text-xs px-1.5 py-0.5 rounded-full">
+                  {formatNumber(trace.tokenUsage.total_tokens)}
+                </span>
+              )}
+            </TabsTrigger>
           </TabsList>
 
           <TabsContent value="logs" className="pt-4">
@@ -695,6 +937,9 @@ const TraceLogs: FC = () => {
           </TabsContent>
           <TabsContent value="timeline" className="pt-4">
             <TimelinePanel trace={trace} />
+          </TabsContent>
+          <TabsContent value="tokens" className="pt-4">
+            <TokenOverviewPanel trace={trace} />
           </TabsContent>
         </Tabs>
 

--- a/graphrag-ui/src/pages/TraceLogs.tsx
+++ b/graphrag-ui/src/pages/TraceLogs.tsx
@@ -1,0 +1,697 @@
+import { FC, useState, useMemo } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import {
+  LuArrowLeft,
+  LuChevronDown,
+  LuChevronUp,
+  LuCopy,
+  LuDownload,
+  LuClock,
+  LuWrench,
+  LuBookOpen,
+  LuActivity,
+} from "react-icons/lu";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface TraceLogEntry {
+  id: number;
+  type: "tool_call" | "tool_result" | "citation";
+  timestamp: string;
+  label: string;
+  detail?: string;
+  durationMs?: number;
+  content?: string;
+  step?: number;
+}
+
+interface ToolCallEntry {
+  id: number;
+  name: string;
+  timestamp: string;
+  durationMs: number;
+  input?: string;
+  output?: string;
+}
+
+interface CitationEntry {
+  id: number;
+  source: string;
+  cited: boolean;
+  text: string;
+}
+
+interface TimelineStep {
+  step: number;
+  name: string;
+  durationMs: number;
+}
+
+interface TraceData {
+  originalQuery: string;
+  conversationContext: string[];
+  status: "completed" | "in_progress" | "failed";
+  sessionId: string;
+  timing: {
+    totalDuration: number;
+    toolExecution: number;
+    llmThinking: number;
+    startTime: string;
+    endTime: string;
+  };
+  logs: TraceLogEntry[];
+  toolCalls: ToolCallEntry[];
+  citations: CitationEntry[];
+  timeline: TimelineStep[];
+  finalResponse: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatDuration(seconds: number): string {
+  if (seconds < 1) return `${(seconds * 1000).toFixed(0)}ms`;
+  return `${seconds.toFixed(2)}s`;
+}
+
+function safeJson(obj: any, maxLen = 2000): string {
+  if (obj == null) return "N/A";
+  if (typeof obj === "string") {
+    try {
+      const parsed = JSON.parse(obj);
+      const pretty = JSON.stringify(parsed, null, 2);
+      return pretty.length > maxLen ? pretty.slice(0, maxLen) + "\n…truncated" : pretty;
+    } catch {
+      return obj.length > maxLen ? obj.slice(0, maxLen) + "\n…truncated" : obj;
+    }
+  }
+  try {
+    const s = JSON.stringify(obj, null, 2);
+    return s.length > maxLen ? s.slice(0, maxLen) + "\n…truncated" : s;
+  } catch {
+    return String(obj);
+  }
+}
+
+function buildTraceFromMessage(message: any, userQuery?: string): TraceData {
+  const now = new Date();
+  const sessionTs = now.toISOString().replace(/[-:T]/g, "").slice(0, 15);
+  const sessionId = `chat_${sessionTs}`;
+
+  const query = userQuery || message?.originalQuery || message?.query || "N/A";
+  const qs = message?.query_sources || {};
+  const responseType = message?.response_type || "";
+  const totalResponseTime = message?.response_time || 0;
+  const ts = now.toLocaleTimeString();
+
+  // ── Tool Calls ──────────────────────────────────────────────────────────
+  // query_sources.agent_steps = array of { node, duration_s } from the
+  // actual LangGraph agent execution (collected in agent.py)
+  const toolCalls: ToolCallEntry[] = [];
+  const agentSteps: { node: string; duration_s: number }[] =
+    qs.agent_steps || [];
+
+  if (agentSteps.length > 0) {
+    agentSteps.forEach((step: { node: string; duration_s: number }, i: number) => {
+      toolCalls.push({
+        id: i + 1,
+        name: step.node,
+        timestamp: ts,
+        durationMs: Math.round(step.duration_s * 1000),
+        input: "",
+        output: "",
+      });
+    });
+  }
+
+  // ── Citations ───────────────────────────────────────────────────────────
+  const rawReasoning = qs.reasoning;
+  const finalRetrieval =
+    typeof qs.result === "object" && qs.result?.final_retrieval
+      ? qs.result.final_retrieval
+      : null;
+  const citations: CitationEntry[] = [];
+
+  if (rawReasoning && Array.isArray(rawReasoning)) {
+    rawReasoning.forEach((src: any, i: number) => {
+      if (src == null) return;
+      const raw = typeof src === "string" ? src : String(src);
+      const cited = raw.startsWith("* ");
+      const chunkName = raw.replace(/^\*\s*/, "");
+
+      let chunkText = "";
+      if (finalRetrieval && finalRetrieval[chunkName]) {
+        const val = finalRetrieval[chunkName];
+        chunkText = Array.isArray(val) ? val.join("\n\n") : String(val);
+      }
+
+      citations.push({
+        id: i + 1,
+        source: chunkName,
+        cited,
+        text: chunkText,
+      });
+    });
+  }
+
+  // ── Logs ────────────────────────────────────────────────────────────────
+  const logs: TraceLogEntry[] = [];
+  let logId = 0;
+  toolCalls.forEach((tc) => {
+    logs.push({
+      id: logId++,
+      type: "tool_call",
+      timestamp: tc.timestamp,
+      label: `${tc.name} - Input`,
+      content: tc.input,
+    });
+    logs.push({
+      id: logId++,
+      type: "tool_result",
+      timestamp: tc.timestamp,
+      label: `${tc.name} - Result`,
+      content: tc.output,
+    });
+  });
+
+  // ── Timeline ────────────────────────────────────────────────────────────
+  const timeline: TimelineStep[] = toolCalls.map((tc, i) => ({
+    step: i + 1,
+    name: tc.name,
+    durationMs: tc.durationMs,
+  }));
+
+  const totalToolSec = agentSteps.reduce(
+    (sum: number, s: { duration_s: number }) => sum + s.duration_s,
+    0
+  );
+  const llmThinking = Math.max(0, totalResponseTime - totalToolSec);
+  const endTime = new Date(now.getTime() + totalResponseTime * 1000);
+
+  return {
+    originalQuery: query,
+    conversationContext: [`user: ${query}`],
+    status: "completed",
+    sessionId,
+    timing: {
+      totalDuration: totalResponseTime,
+      toolExecution: totalToolSec,
+      llmThinking,
+      startTime: now.toLocaleTimeString(),
+      endTime: endTime.toLocaleTimeString(),
+    },
+    logs,
+    toolCalls,
+    citations,
+    timeline,
+    finalResponse: message?.content || "",
+  };
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+const StatusBadge: FC<{ status: string }> = ({ status }) => {
+  const color =
+    status === "completed"
+      ? "bg-emerald-500"
+      : status === "in_progress"
+        ? "bg-blue-500"
+        : "bg-red-500";
+  return (
+    <span
+      className={`${color} text-white text-xs font-medium px-3 py-1 rounded-full`}
+    >
+      {status}
+    </span>
+  );
+};
+
+const TimingRow: FC<{
+  items: { value: string; label: string; color: string }[];
+}> = ({ items }) => (
+  <div className="flex border border-border rounded-lg overflow-hidden bg-card">
+    {items.map((item, i) => (
+      <div
+        key={item.label}
+        className={`flex-1 flex flex-col items-center justify-center py-5 ${
+          i < items.length - 1 ? "border-r border-border" : ""
+        }`}
+      >
+        <span className={`text-2xl font-bold ${item.color}`}>
+          {item.value}
+        </span>
+        <span className="text-xs text-muted-foreground mt-1">
+          {item.label}
+        </span>
+      </div>
+    ))}
+  </div>
+);
+
+const ExpandableRow: FC<{
+  children: React.ReactNode;
+  content?: string;
+  defaultOpen?: boolean;
+}> = ({ children, content, defaultOpen = false }) => {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border border-border rounded-lg mb-2 overflow-hidden">
+      <div
+        className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-muted/50 transition-colors"
+        onClick={() => setOpen((p) => !p)}
+      >
+        <div className="flex items-center gap-3 flex-1 min-w-0">
+          {children}
+        </div>
+        <div className="flex items-center gap-2 ml-2 shrink-0">
+          {content && (
+            <button
+              className="p-1 hover:bg-muted rounded"
+              onClick={(e) => {
+                e.stopPropagation();
+                navigator.clipboard.writeText(content);
+              }}
+              title="Copy"
+            >
+              <LuCopy className="w-4 h-4 text-muted-foreground" />
+            </button>
+          )}
+          {open ? (
+            <LuChevronUp className="w-4 h-4 text-muted-foreground" />
+          ) : (
+            <LuChevronDown className="w-4 h-4 text-muted-foreground" />
+          )}
+        </div>
+      </div>
+      {open && content && (
+        <div className="px-4 pb-3 text-sm text-muted-foreground border-t border-border pt-3">
+          <pre className="whitespace-pre-wrap font-sans">{content}</pre>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ─── Tab Panels ───────────────────────────────────────────────────────────────
+
+const LogsPanel: FC<{ trace: TraceData }> = ({ trace }) => {
+  const [collapsed, setCollapsed] = useState(false);
+  const toolCount = trace.logs.filter(
+    (l) => l.type === "tool_call" || l.type === "tool_result"
+  ).length;
+  const citationCount = trace.citations.length;
+  const totalEvents = trace.logs.length;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-4 text-sm">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-muted-foreground">
+            {trace.logs.length} log entries ({totalEvents} events)
+          </span>
+          <span className="bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-xs px-2 py-0.5 rounded-full">
+            Tools ({toolCount})
+          </span>
+          <span className="bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 text-xs px-2 py-0.5 rounded-full">
+            Citations ({citationCount})
+          </span>
+        </div>
+        <button
+          className="text-blue-600 dark:text-blue-400 text-xs hover:underline"
+          onClick={() => setCollapsed((p) => !p)}
+        >
+          {collapsed ? "Expand All" : "Collapse All"}
+        </button>
+      </div>
+
+      <div className="space-y-0">
+        {trace.logs.map((log) => {
+          const isToolCall = log.type === "tool_call";
+          const isToolResult = log.type === "tool_result";
+
+          const dotColor = isToolResult
+            ? "bg-emerald-500"
+            : "bg-blue-500";
+          const iconBg = isToolResult
+            ? "text-emerald-600 dark:text-emerald-400"
+            : "text-blue-600 dark:text-blue-400";
+          const typeLabel = isToolCall
+            ? "Tool Call"
+            : "Tool Result";
+
+          return (
+            <div key={log.id} className="flex items-start gap-3">
+              <div className="flex flex-col items-center pt-5">
+                <div className={`w-2.5 h-2.5 rounded-full ${dotColor}`} />
+                <div className="w-px h-full bg-border min-h-[20px]" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <ExpandableRow
+                  content={log.content}
+                  defaultOpen={!collapsed && log.id === 0}
+                >
+                  <span className={`text-xs font-medium ${iconBg}`}>
+                    {isToolCall && <LuWrench className="inline w-3.5 h-3.5 mr-1" />}
+                    {isToolResult && "✓ "}
+                    {typeLabel}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {log.timestamp}
+                  </span>
+                  <span className="text-sm font-medium truncate">
+                    {log.label}
+                  </span>
+                  {log.durationMs && (
+                    <span className="text-xs text-emerald-600 dark:text-emerald-400">
+                      ({log.durationMs}ms)
+                    </span>
+                  )}
+                </ExpandableRow>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+const ToolCallExpandable: FC<{ tc: ToolCallEntry }> = ({ tc }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="border border-border rounded-lg mb-2 overflow-hidden">
+      <div
+        className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-muted/50 transition-colors"
+        onClick={() => setOpen((p) => !p)}
+      >
+        <div className="flex items-center gap-3 flex-1 min-w-0">
+          <span className="flex items-center justify-center w-7 h-7 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 text-xs font-bold shrink-0">
+            {tc.id}
+          </span>
+          <span className="text-sm font-semibold truncate">{tc.name}</span>
+          <span className="text-xs text-muted-foreground">{tc.timestamp}</span>
+        </div>
+        <div className="flex items-center gap-2 ml-2 shrink-0">
+          {tc.durationMs > 0 && (
+            <span className="bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 text-xs font-medium px-2 py-0.5 rounded-full">
+              {tc.durationMs}ms
+            </span>
+          )}
+          {open ? (
+            <LuChevronUp className="w-4 h-4 text-muted-foreground" />
+          ) : (
+            <LuChevronDown className="w-4 h-4 text-muted-foreground" />
+          )}
+        </div>
+      </div>
+      {open && (
+        <div className="px-4 pb-4 space-y-3">
+          <div>
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1">
+              Input
+            </p>
+            <pre className="bg-[#1e1e2e] dark:bg-[#0d1117] text-emerald-300 text-xs rounded-lg p-4 overflow-auto max-h-[300px] whitespace-pre-wrap">
+              {tc.input || "N/A"}
+            </pre>
+          </div>
+          <div>
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1">
+              Result
+            </p>
+            <pre className="bg-[#1e1e2e] dark:bg-[#0d1117] text-blue-300 text-xs rounded-lg p-4 overflow-auto max-h-[300px] whitespace-pre-wrap">
+              {tc.output || "N/A"}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ToolCallsPanel: FC<{ trace: TraceData }> = ({ trace }) => (
+  <div className="space-y-2">
+    {trace.toolCalls.map((tc) => (
+      <ToolCallExpandable key={tc.id} tc={tc} />
+    ))}
+  </div>
+);
+
+
+const CitationRow: FC<{ c: CitationEntry }> = ({ c }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <div
+      className={`rounded-lg mb-2 overflow-hidden ${
+        c.cited
+          ? "bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800"
+          : "bg-orange-50 dark:bg-orange-900/15 border border-orange-200 dark:border-orange-800"
+      }`}
+    >
+      <div
+        className="flex items-center justify-between px-4 py-3 cursor-pointer"
+        onClick={() => setOpen((p) => !p)}
+      >
+        <div className="flex items-center gap-3 flex-1 min-w-0">
+          <LuBookOpen className="w-4 h-4 text-amber-700 dark:text-amber-400 shrink-0" />
+          <span className="text-sm font-semibold truncate">
+            [{c.source}]
+          </span>
+          {c.cited && (
+            <span className="bg-red-500 text-white text-xs font-medium px-2.5 py-0.5 rounded-full shrink-0">
+              Cited
+            </span>
+          )}
+        </div>
+        <div className="ml-2 shrink-0">
+          {open ? (
+            <LuChevronUp className="w-4 h-4 text-muted-foreground" />
+          ) : (
+            <LuChevronDown className="w-4 h-4 text-muted-foreground" />
+          )}
+        </div>
+      </div>
+      {open && (
+        <div className="px-4 pb-4 text-sm text-foreground/80 whitespace-pre-wrap border-t border-amber-200 dark:border-amber-800 pt-3">
+          {c.text || "No content retrieved for this chunk."}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const CitationsPanel: FC<{ trace: TraceData }> = ({ trace }) => (
+  <div className="space-y-2">
+    {trace.citations.length === 0 ? (
+      <p className="text-sm text-muted-foreground py-4">
+        No citations available for this trace.
+      </p>
+    ) : (
+      trace.citations.map((c) => <CitationRow key={c.id} c={c} />)
+    )}
+  </div>
+);
+
+const TimelinePanel: FC<{ trace: TraceData }> = ({ trace }) => (
+  <div className="relative pl-4">
+    {trace.timeline.map((item, i) => (
+      <div key={i} className="flex items-start gap-6 mb-6 last:mb-0">
+        <div className="w-16 text-sm text-muted-foreground pt-1 shrink-0">
+          Step {item.step}
+        </div>
+        <div className="flex flex-col items-start gap-1">
+          <span className="bg-blue-600 text-white text-xs font-bold px-3 py-1 rounded-full">
+            {item.durationMs}ms
+          </span>
+          <span className="text-sm text-muted-foreground">{item.name}</span>
+        </div>
+      </div>
+    ))}
+  </div>
+);
+
+// ─── Main Page ────────────────────────────────────────────────────────────────
+
+const TraceLogs: FC = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const message = location.state?.message;
+  const userQuery = location.state?.userQuery;
+
+  const trace = useMemo(
+    () => buildTraceFromMessage(message, userQuery),
+    [message, userQuery]
+  );
+
+  const handleBack = () => {
+    navigate(-1);
+  };
+
+  const handleDownload = () => {
+    const blob = new Blob([JSON.stringify(trace, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `trace_${trace.sessionId}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-background border-b border-border">
+        <div className="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
+          <div>
+            <button
+              onClick={handleBack}
+              className="flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:underline mb-1"
+            >
+              <LuArrowLeft className="w-4 h-4" />
+              Back to Chat
+            </button>
+            <h1 className="text-xl font-semibold">Trace Logs</h1>
+          </div>
+          <div className="flex items-center gap-3">
+            <StatusBadge status={trace.status} />
+            <span className="text-xs text-muted-foreground hidden sm:inline">
+              Session: {trace.sessionId}
+            </span>
+            <button
+              onClick={handleDownload}
+              className="flex items-center gap-1.5 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+            >
+              <LuDownload className="w-4 h-4" />
+              Download
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-5xl mx-auto px-6 py-6 space-y-6">
+        {/* Original Query */}
+        <div className="bg-card border border-border rounded-lg p-5">
+          <h2 className="text-sm font-semibold mb-2">Original Query</h2>
+          <div className="bg-muted rounded-md px-4 py-3 text-sm">
+            {trace.originalQuery}
+          </div>
+        </div>
+
+        {/* Conversation Context */}
+        <div className="bg-card border border-border rounded-lg p-5">
+          <h2 className="text-sm font-semibold mb-2">Conversation Context</h2>
+          <div className="space-y-1">
+            {trace.conversationContext.map((line, i) => (
+              <p key={i} className="text-sm text-muted-foreground">
+                {line}
+              </p>
+            ))}
+          </div>
+        </div>
+
+        {/* Timing Overview */}
+        <div className="bg-card border border-border rounded-lg p-5">
+          <h2 className="text-sm font-semibold mb-4">Timing Overview</h2>
+          <TimingRow
+            items={[
+              {
+                value: formatDuration(trace.timing.totalDuration),
+                label: "Total Duration",
+                color: "text-blue-600 dark:text-blue-400",
+              },
+              {
+                value: formatDuration(trace.timing.toolExecution),
+                label: "Tool Execution",
+                color: "text-emerald-600 dark:text-emerald-400",
+              },
+              {
+                value: formatDuration(trace.timing.llmThinking),
+                label: "LLM Thinking",
+                color: "text-red-500 dark:text-red-400",
+              },
+            ]}
+          />
+          {/* Timeline bar */}
+          <div className="relative">
+            <div className="flex items-center gap-2 mb-1">
+              <div className="w-3 h-3 rounded-full bg-emerald-500 shrink-0" />
+              <div className="flex-1 h-3 rounded-full bg-gradient-to-r from-blue-500 via-purple-500 to-purple-600" />
+            </div>
+            <div className="flex justify-between text-xs text-muted-foreground">
+              <span>Start</span>
+              <span>{trace.timing.startTime}</span>
+              <span>{trace.timing.endTime}</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <Tabs defaultValue="logs" className="w-full">
+          <TabsList className="w-full justify-start bg-transparent border-b border-border rounded-none h-auto p-0 gap-0">
+            <TabsTrigger
+              value="logs"
+              className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 py-2.5"
+            >
+              <LuActivity className="w-4 h-4 mr-1.5" />
+              Logs
+            </TabsTrigger>
+            <TabsTrigger
+              value="toolcalls"
+              className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 py-2.5"
+            >
+              Tool Calls
+              <span className="ml-1.5 bg-muted text-muted-foreground text-xs px-1.5 py-0.5 rounded-full">
+                {trace.toolCalls.length}
+              </span>
+            </TabsTrigger>
+            <TabsTrigger
+              value="citations"
+              className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 py-2.5"
+            >
+              Citations
+              <span className="ml-1.5 bg-muted text-muted-foreground text-xs px-1.5 py-0.5 rounded-full">
+                {trace.citations.length}
+              </span>
+            </TabsTrigger>
+            <TabsTrigger
+              value="timeline"
+              className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 py-2.5"
+            >
+              Timeline
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="logs" className="pt-4">
+            <LogsPanel trace={trace} />
+          </TabsContent>
+          <TabsContent value="toolcalls" className="pt-4">
+            <ToolCallsPanel trace={trace} />
+          </TabsContent>
+          <TabsContent value="citations" className="pt-4">
+            <CitationsPanel trace={trace} />
+          </TabsContent>
+          <TabsContent value="timeline" className="pt-4">
+            <TimelinePanel trace={trace} />
+          </TabsContent>
+        </Tabs>
+
+        {/* Final Response */}
+        {trace.finalResponse && (
+          <div className="bg-card border border-border rounded-lg p-5">
+            <h2 className="text-sm font-semibold mb-3">Final Response</h2>
+            <div className="prose dark:prose-invert text-sm max-w-none">
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {trace.finalResponse}
+              </ReactMarkdown>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TraceLogs;

--- a/graphrag-ui/src/pages/TraceLogs.tsx
+++ b/graphrag-ui/src/pages/TraceLogs.tsx
@@ -742,13 +742,23 @@ const TraceLogs: FC = () => {
   const stateMessage = location.state?.message;
   const stateUserQuery = location.state?.userQuery;
 
+  // Check sessionStorage for message stored by the opener tab before API fetch.
+  const sessionKey = messageId ? `trace_msg_${messageId}` : null;
+  const sessionRaw = sessionKey ? sessionStorage.getItem(sessionKey) : null;
+  const sessionMessage = sessionRaw ? JSON.parse(sessionRaw) : null;
+
+  const resolvedMessage = stateMessage || sessionMessage;
+
   const [apiData, setApiData] = useState<any>(null);
-  const [loading, setLoading] = useState(!stateMessage);
+  const [loading, setLoading] = useState(!resolvedMessage);
 
   useEffect(() => {
-    if (stateMessage || !messageId) return;
+    if (resolvedMessage || !messageId) return;
     setLoading(true);
-    fetch(`/ui/trace/${messageId}`)
+    const creds = sessionStorage.getItem("creds");
+    fetch(`/ui/trace/${messageId}`, {
+      headers: { Authorization: `Basic ${creds}` },
+    })
       .then((res) => {
         if (!res.ok) throw new Error("Not found");
         return res.json();
@@ -756,15 +766,15 @@ const TraceLogs: FC = () => {
       .then((data) => setApiData(data))
       .catch(() => setApiData(null))
       .finally(() => setLoading(false));
-  }, [messageId, stateMessage]);
+  }, [messageId, resolvedMessage]);
 
-  const message = stateMessage || (apiData ? {
+  const message = resolvedMessage || (apiData ? {
     content: apiData.natural_language_response,
     response_time: apiData.response_time,
     response_type: apiData.response_type,
     query_sources: apiData.query_sources,
   } : null);
-  const userQuery = stateUserQuery || apiData?.user_query;
+  const userQuery = stateUserQuery || sessionMessage?.userQuery || apiData?.user_query;
 
   const trace = useMemo(
     () => buildTraceFromMessage(message, userQuery),
@@ -817,10 +827,6 @@ const TraceLogs: FC = () => {
             <h1 className="text-xl font-semibold">Trace Logs</h1>
           </div>
           <div className="flex items-center gap-3">
-            <StatusBadge status={trace.status} />
-            <span className="text-xs text-muted-foreground hidden sm:inline">
-              Session: {trace.sessionId}
-            </span>
             <button
               onClick={handleDownload}
               className="flex items-center gap-1.5 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"

--- a/graphrag-ui/src/pages/TraceLogs.tsx
+++ b/graphrag-ui/src/pages/TraceLogs.tsx
@@ -7,7 +7,6 @@ import {
   LuChevronUp,
   LuCopy,
   LuDownload,
-  LuClock,
   LuWrench,
   LuBookOpen,
   LuActivity,

--- a/graphrag-ui/src/pages/TraceLogs.tsx
+++ b/graphrag-ui/src/pages/TraceLogs.tsx
@@ -102,26 +102,23 @@ function buildTraceFromMessage(message: any, userQuery?: string): TraceData {
 
   const query = userQuery || message?.originalQuery || message?.query || "N/A";
   const qs = message?.query_sources || {};
-  const responseType = message?.response_type || "";
   const totalResponseTime = message?.response_time || 0;
   const ts = now.toLocaleTimeString();
 
   // ── Tool Calls ──────────────────────────────────────────────────────────
-  // query_sources.agent_steps = array of { node, duration_s } from the
-  // actual LangGraph agent execution (collected in agent.py)
   const toolCalls: ToolCallEntry[] = [];
-  const agentSteps: { node: string; duration_s: number }[] =
+  const agentSteps: { node: string; duration_s: number; input?: string; output?: string }[] =
     qs.agent_steps || [];
 
   if (agentSteps.length > 0) {
-    agentSteps.forEach((step: { node: string; duration_s: number }, i: number) => {
+    agentSteps.forEach((step, i: number) => {
       toolCalls.push({
         id: i + 1,
         name: step.node,
         timestamp: ts,
         durationMs: Math.round(step.duration_s * 1000),
-        input: "",
-        output: "",
+        input: safeJson(step.input),
+        output: safeJson(step.output),
       });
     });
   }

--- a/graphrag-ui/src/pages/TraceLogs.tsx
+++ b/graphrag-ui/src/pages/TraceLogs.tsx
@@ -1,5 +1,5 @@
-import { FC, useState, useMemo } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { FC, useState, useMemo, useEffect } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import {
   LuArrowLeft,
@@ -18,7 +18,7 @@ import remarkGfm from "remark-gfm";
 
 interface TraceLogEntry {
   id: number;
-  type: "tool_call" | "tool_result" | "citation";
+  type: "tool_call" | "citation";
   timestamp: string;
   label: string;
   detail?: string;
@@ -75,24 +75,35 @@ function formatDuration(seconds: number): string {
   return `${seconds.toFixed(2)}s`;
 }
 
-function safeJson(obj: any, maxLen = 2000): string {
+function safeJson(obj: any): string {
   if (obj == null) return "N/A";
   if (typeof obj === "string") {
     try {
-      const parsed = JSON.parse(obj);
-      const pretty = JSON.stringify(parsed, null, 2);
-      return pretty.length > maxLen ? pretty.slice(0, maxLen) + "\n…truncated" : pretty;
+      return JSON.stringify(JSON.parse(obj), null, 2);
     } catch {
-      return obj.length > maxLen ? obj.slice(0, maxLen) + "\n…truncated" : obj;
+      return obj;
     }
   }
   try {
-    const s = JSON.stringify(obj, null, 2);
-    return s.length > maxLen ? s.slice(0, maxLen) + "\n…truncated" : s;
+    return JSON.stringify(obj, null, 2);
   } catch {
     return String(obj);
   }
 }
+
+const NODE_LABELS: Record<string, string> = {
+  entry: "Entry",
+  supportai: "SupportAI",
+  map_question_to_schema: "Map Question to Schema",
+  generate_function: "Generate Function",
+  generate_cypher: "Generate Cypher",
+  generate_answer: "Generate Answer",
+  lookup_history: "Lookup History",
+  merge_history_context: "Merge History Context",
+  rewrite_question: "Rewrite Question",
+  apologize: "Apologize",
+  greet: "Greet",
+};
 
 function buildTraceFromMessage(message: any, userQuery?: string): TraceData {
   const now = new Date();
@@ -113,7 +124,7 @@ function buildTraceFromMessage(message: any, userQuery?: string): TraceData {
     agentSteps.forEach((step, i: number) => {
       toolCalls.push({
         id: i + 1,
-        name: step.node,
+        name: NODE_LABELS[step.node] || step.node,
         timestamp: ts,
         durationMs: Math.round(step.duration_s * 1000),
         input: safeJson(step.input),
@@ -160,14 +171,15 @@ function buildTraceFromMessage(message: any, userQuery?: string): TraceData {
       id: logId++,
       type: "tool_call",
       timestamp: tc.timestamp,
-      label: `${tc.name} - Input`,
+      label: `${tc.name} — Input`,
       content: tc.input,
+      durationMs: tc.durationMs,
     });
     logs.push({
       id: logId++,
-      type: "tool_result",
+      type: "citation",
       timestamp: tc.timestamp,
-      label: `${tc.name} - Result`,
+      label: `${tc.name} — Output`,
       content: tc.output,
     });
   });
@@ -283,7 +295,7 @@ const ExpandableRow: FC<{
       </div>
       {open && content && (
         <div className="px-4 pb-3 text-sm text-muted-foreground border-t border-border pt-3">
-          <pre className="whitespace-pre-wrap font-sans">{content}</pre>
+          <pre className="whitespace-pre-wrap font-sans overflow-auto max-h-[500px]">{content}</pre>
         </div>
       )}
     </div>
@@ -294,24 +306,19 @@ const ExpandableRow: FC<{
 
 const LogsPanel: FC<{ trace: TraceData }> = ({ trace }) => {
   const [collapsed, setCollapsed] = useState(false);
-  const toolCount = trace.logs.filter(
-    (l) => l.type === "tool_call" || l.type === "tool_result"
-  ).length;
-  const citationCount = trace.citations.length;
-  const totalEvents = trace.logs.length;
 
   return (
     <div>
       <div className="flex items-center justify-between mb-4 text-sm">
         <div className="flex items-center gap-2 flex-wrap">
           <span className="text-muted-foreground">
-            {trace.logs.length} log entries ({totalEvents} events)
+            {trace.logs.length} agent steps
           </span>
           <span className="bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 text-xs px-2 py-0.5 rounded-full">
-            Tools ({toolCount})
+            Nodes ({trace.toolCalls.length})
           </span>
           <span className="bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 text-xs px-2 py-0.5 rounded-full">
-            Citations ({citationCount})
+            Citations ({trace.citations.length})
           </span>
         </div>
         <button
@@ -323,52 +330,36 @@ const LogsPanel: FC<{ trace: TraceData }> = ({ trace }) => {
       </div>
 
       <div className="space-y-0">
-        {trace.logs.map((log) => {
-          const isToolCall = log.type === "tool_call";
-          const isToolResult = log.type === "tool_result";
-
-          const dotColor = isToolResult
-            ? "bg-emerald-500"
-            : "bg-blue-500";
-          const iconBg = isToolResult
-            ? "text-emerald-600 dark:text-emerald-400"
-            : "text-blue-600 dark:text-blue-400";
-          const typeLabel = isToolCall
-            ? "Tool Call"
-            : "Tool Result";
-
-          return (
-            <div key={log.id} className="flex items-start gap-3">
-              <div className="flex flex-col items-center pt-5">
-                <div className={`w-2.5 h-2.5 rounded-full ${dotColor}`} />
-                <div className="w-px h-full bg-border min-h-[20px]" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <ExpandableRow
-                  content={log.content}
-                  defaultOpen={!collapsed && log.id === 0}
-                >
-                  <span className={`text-xs font-medium ${iconBg}`}>
-                    {isToolCall && <LuWrench className="inline w-3.5 h-3.5 mr-1" />}
-                    {isToolResult && "✓ "}
-                    {typeLabel}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {log.timestamp}
-                  </span>
-                  <span className="text-sm font-medium truncate">
-                    {log.label}
-                  </span>
-                  {log.durationMs && (
-                    <span className="text-xs text-emerald-600 dark:text-emerald-400">
-                      ({log.durationMs}ms)
-                    </span>
-                  )}
-                </ExpandableRow>
-              </div>
+        {trace.logs.map((log) => (
+          <div key={log.id} className="flex items-start gap-3">
+            <div className="flex flex-col items-center pt-5">
+              <div className="w-2.5 h-2.5 rounded-full bg-blue-500" />
+              <div className="w-px h-full bg-border min-h-[20px]" />
             </div>
-          );
-        })}
+            <div className="flex-1 min-w-0">
+              <ExpandableRow
+                content={log.content}
+                defaultOpen={!collapsed && log.id === 0}
+              >
+                <span className="text-xs font-medium text-blue-600 dark:text-blue-400">
+                  <LuWrench className="inline w-3.5 h-3.5 mr-1" />
+                  Node
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {log.timestamp}
+                </span>
+                <span className="text-sm font-medium truncate">
+                  {log.label}
+                </span>
+                {log.durationMs != null && log.durationMs > 0 && (
+                  <span className="text-xs text-emerald-600 dark:text-emerald-400">
+                    ({log.durationMs}ms)
+                  </span>
+                )}
+              </ExpandableRow>
+            </div>
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -408,15 +399,15 @@ const ToolCallExpandable: FC<{ tc: ToolCallEntry }> = ({ tc }) => {
             <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1">
               Input
             </p>
-            <pre className="bg-[#1e1e2e] dark:bg-[#0d1117] text-emerald-300 text-xs rounded-lg p-4 overflow-auto max-h-[300px] whitespace-pre-wrap">
+            <pre className="bg-[#1e1e2e] dark:bg-[#0d1117] text-emerald-300 text-xs rounded-lg p-4 overflow-auto max-h-[500px] whitespace-pre-wrap">
               {tc.input || "N/A"}
             </pre>
           </div>
           <div>
             <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1">
-              Result
+              Output
             </p>
-            <pre className="bg-[#1e1e2e] dark:bg-[#0d1117] text-blue-300 text-xs rounded-lg p-4 overflow-auto max-h-[300px] whitespace-pre-wrap">
+            <pre className="bg-[#1e1e2e] dark:bg-[#0d1117] text-blue-300 text-xs rounded-lg p-4 overflow-auto max-h-[500px] whitespace-pre-wrap">
               {tc.output || "N/A"}
             </pre>
           </div>
@@ -512,8 +503,34 @@ const TimelinePanel: FC<{ trace: TraceData }> = ({ trace }) => (
 const TraceLogs: FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const message = location.state?.message;
-  const userQuery = location.state?.userQuery;
+  const { messageId } = useParams<{ messageId: string }>();
+
+  const stateMessage = location.state?.message;
+  const stateUserQuery = location.state?.userQuery;
+
+  const [apiData, setApiData] = useState<any>(null);
+  const [loading, setLoading] = useState(!stateMessage);
+
+  useEffect(() => {
+    if (stateMessage || !messageId) return;
+    setLoading(true);
+    fetch(`/ui/trace/${messageId}`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Not found");
+        return res.json();
+      })
+      .then((data) => setApiData(data))
+      .catch(() => setApiData(null))
+      .finally(() => setLoading(false));
+  }, [messageId, stateMessage]);
+
+  const message = stateMessage || (apiData ? {
+    content: apiData.natural_language_response,
+    response_time: apiData.response_time,
+    response_type: apiData.response_type,
+    query_sources: apiData.query_sources,
+  } : null);
+  const userQuery = stateUserQuery || apiData?.user_query;
 
   const trace = useMemo(
     () => buildTraceFromMessage(message, userQuery),
@@ -535,6 +552,14 @@ const TraceLogs: FC = () => {
     a.click();
     URL.revokeObjectURL(url);
   };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <p className="text-muted-foreground">Loading trace data...</p>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-background">

--- a/graphrag-ui/src/pages/TraceLogs.tsx
+++ b/graphrag-ui/src/pages/TraceLogs.tsx
@@ -864,8 +864,17 @@ const TraceLogs: FC = () => {
         </div>
 
         {/* Tabs */}
-        <Tabs defaultValue="logs" className="w-full">
+        <Tabs defaultValue="citations" className="w-full">
           <TabsList className="w-full justify-start bg-transparent border-b border-border rounded-none h-auto p-0 gap-0">
+            <TabsTrigger
+              value="citations"
+              className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 py-2.5"
+            >
+              Citations
+              <span className="ml-1.5 bg-muted text-muted-foreground text-xs px-1.5 py-0.5 rounded-full">
+                {trace.citations.length}
+              </span>
+            </TabsTrigger>
             <TabsTrigger
               value="logs"
               className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 py-2.5"
@@ -880,15 +889,6 @@ const TraceLogs: FC = () => {
               Tool Calls
               <span className="ml-1.5 bg-muted text-muted-foreground text-xs px-1.5 py-0.5 rounded-full">
                 {trace.toolCalls.length}
-              </span>
-            </TabsTrigger>
-            <TabsTrigger
-              value="citations"
-              className="rounded-none border-b-2 border-transparent data-[state=active]:border-blue-600 data-[state=active]:bg-transparent data-[state=active]:shadow-none px-4 py-2.5"
-            >
-              Citations
-              <span className="ml-1.5 bg-muted text-muted-foreground text-xs px-1.5 py-0.5 rounded-full">
-                {trace.citations.length}
               </span>
             </TabsTrigger>
             <TabsTrigger
@@ -911,14 +911,14 @@ const TraceLogs: FC = () => {
             </TabsTrigger>
           </TabsList>
 
+          <TabsContent value="citations" className="pt-4">
+            <CitationsPanel trace={trace} />
+          </TabsContent>
           <TabsContent value="logs" className="pt-4">
             <LogsPanel trace={trace} />
           </TabsContent>
           <TabsContent value="toolcalls" className="pt-4">
             <ToolCallsPanel trace={trace} />
-          </TabsContent>
-          <TabsContent value="citations" className="pt-4">
-            <CitationsPanel trace={trace} />
           </TabsContent>
           <TabsContent value="timeline" className="pt-4">
             <TimelinePanel trace={trace} />

--- a/graphrag-ui/src/pages/TraceLogs.tsx
+++ b/graphrag-ui/src/pages/TraceLogs.tsx
@@ -156,10 +156,6 @@ function buildTraceFromMessage(message: any, userQuery?: string): TraceData {
 
   // ── Citations ───────────────────────────────────────────────────────────
   const rawReasoning = qs.reasoning;
-  const finalRetrieval =
-    typeof qs.result === "object" && qs.result?.final_retrieval
-      ? qs.result.final_retrieval
-      : null;
   const citations: CitationEntry[] = [];
 
   if (rawReasoning && Array.isArray(rawReasoning)) {
@@ -169,17 +165,11 @@ function buildTraceFromMessage(message: any, userQuery?: string): TraceData {
       const cited = raw.startsWith("* ");
       const chunkName = raw.replace(/^\*\s*/, "");
 
-      let chunkText = "";
-      if (finalRetrieval && finalRetrieval[chunkName]) {
-        const val = finalRetrieval[chunkName];
-        chunkText = Array.isArray(val) ? val.join("\n\n") : String(val);
-      }
-
       citations.push({
         id: i + 1,
         source: chunkName,
         cited,
-        text: chunkText,
+        text: "",
       });
     });
   }
@@ -524,47 +514,25 @@ const ToolCallsPanel: FC<{ trace: TraceData }> = ({ trace }) => (
 );
 
 
-const CitationRow: FC<{ c: CitationEntry }> = ({ c }) => {
-  const [open, setOpen] = useState(false);
-  return (
-    <div
-      className={`rounded-lg mb-2 overflow-hidden ${
-        c.cited
-          ? "bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800"
-          : "bg-orange-50 dark:bg-orange-900/15 border border-orange-200 dark:border-orange-800"
-      }`}
-    >
-      <div
-        className="flex items-center justify-between px-4 py-3 cursor-pointer"
-        onClick={() => setOpen((p) => !p)}
-      >
-        <div className="flex items-center gap-3 flex-1 min-w-0">
-          <LuBookOpen className="w-4 h-4 text-amber-700 dark:text-amber-400 shrink-0" />
-          <span className="text-sm font-semibold truncate">
-            [{c.source}]
-          </span>
-          {c.cited && (
-            <span className="bg-red-500 text-white text-xs font-medium px-2.5 py-0.5 rounded-full shrink-0">
-              Cited
-            </span>
-          )}
-        </div>
-        <div className="ml-2 shrink-0">
-          {open ? (
-            <LuChevronUp className="w-4 h-4 text-muted-foreground" />
-          ) : (
-            <LuChevronDown className="w-4 h-4 text-muted-foreground" />
-          )}
-        </div>
-      </div>
-      {open && (
-        <div className="px-4 pb-4 text-sm text-foreground/80 whitespace-pre-wrap border-t border-amber-200 dark:border-amber-800 pt-3">
-          {c.text || "No content retrieved for this chunk."}
-        </div>
+const CitationRow: FC<{ c: CitationEntry }> = ({ c }) => (
+  <div
+    className={`rounded-lg mb-2 ${
+      c.cited
+        ? "bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800"
+        : "bg-orange-50 dark:bg-orange-900/15 border border-orange-200 dark:border-orange-800"
+    }`}
+  >
+    <div className="flex items-center gap-3 px-4 py-3">
+      <LuBookOpen className="w-4 h-4 text-amber-700 dark:text-amber-400 shrink-0" />
+      <span className="text-sm font-semibold truncate">[{c.source}]</span>
+      {c.cited && (
+        <span className="bg-red-500 text-white text-xs font-medium px-2.5 py-0.5 rounded-full shrink-0">
+          Cited
+        </span>
       )}
     </div>
-  );
-};
+  </div>
+);
 
 const CitationsPanel: FC<{ trace: TraceData }> = ({ trace }) => (
   <div className="space-y-2">

--- a/graphrag/app/agent/agent.py
+++ b/graphrag/app/agent/agent.py
@@ -11,7 +11,7 @@ from tools import GenerateCypher, GenerateFunction, MapQuestionToSchema
 from common.config import embedding_service, embedding_store, llm_config, get_completion_config, get_chat_config, get_llm_service
 from common.embeddings.base_embedding_store import EmbeddingStore
 from common.embeddings.embedding_services import EmbeddingModel
-from common.llm_services.base_llm import LLM_Model
+from common.llm_services.base_llm import LLM_Model, start_usage_collection, get_collected_usage
 from common.logs.log import req_id_cv
 from common.logs.logwriter import LogWriter
 from common.metrics.prometheus_metrics import metrics
@@ -181,17 +181,47 @@ class TigerGraphAgent:
             step_start = time.time()
             prev_state = {"question": input_data["input"], "conversation": input_data["conversation"]}
 
+            # Start collecting LLM usage so we can attribute tokens/cost per node.
+            start_usage_collection()
+
             for output in self.agent.stream({"question": input_data["input"], "conversation": input_data["conversation"]}):
 
                 for key, value in output.items():
                     step_end = time.time()
                     step_duration = round(step_end - step_start, 3)
+
+                    # Grab usage accumulated during this node and reset for next node.
+                    node_usage = get_collected_usage() or []
+                    input_tokens = sum(int(u.get("input_tokens", 0) or 0) for u in node_usage)
+                    output_tokens = sum(int(u.get("output_tokens", 0) or 0) for u in node_usage)
+                    total_tokens = sum(int(u.get("total_tokens", 0) or 0) for u in node_usage)
+                    cost = sum(float(u.get("cost", 0) or 0) for u in node_usage)
+
                     agent_steps.append({
                         "node": key,
                         "duration_s": step_duration,
                         "input": _safe(prev_state),
                         "output": _node_output(key, value),
+                        "usage": {
+                            "input_tokens": input_tokens,
+                            "output_tokens": output_tokens,
+                            "total_tokens": total_tokens,
+                            "cost": cost,
+                            "calls": [
+                                {
+                                    "caller_name": u.get("caller_name"),
+                                    "input_tokens": u.get("input_tokens", 0),
+                                    "output_tokens": u.get("output_tokens", 0),
+                                    "total_tokens": u.get("total_tokens", 0),
+                                    "cost": u.get("cost", 0),
+                                }
+                                for u in node_usage
+                            ],
+                        },
                     })
+                    # Reset the collector for the next node.
+                    start_usage_collection()
+
                     prev_state = value
                     LogWriter.info(
                         f"request_id={req_id_cv.get()} executed node {key} ({step_duration}s)"
@@ -207,6 +237,15 @@ class TigerGraphAgent:
             if value["answer"].query_sources is None:
                 value["answer"].query_sources = {}
             value["answer"].query_sources["agent_steps"] = agent_steps
+
+            # Aggregate total LLM usage across all nodes for the Token Overview UI.
+            total_usage = {
+                "input_tokens": sum(int(s.get("usage", {}).get("input_tokens", 0) or 0) for s in agent_steps),
+                "output_tokens": sum(int(s.get("usage", {}).get("output_tokens", 0) or 0) for s in agent_steps),
+                "total_tokens": sum(int(s.get("usage", {}).get("total_tokens", 0) or 0) for s in agent_steps),
+                "cost": sum(float(s.get("usage", {}).get("cost", 0) or 0) for s in agent_steps),
+            }
+            value["answer"].query_sources["token_usage"] = total_usage
 
             LogWriter.info(f"request_id={req_id_cv.get()} EXIT question_for_agent")
             return value["answer"]

--- a/graphrag/app/agent/agent.py
+++ b/graphrag/app/agent/agent.py
@@ -129,14 +129,30 @@ class TigerGraphAgent:
                 logger.error(f"Failed to serialize input_data to JSON: {e}")
                 raise ValueError("Invalid input data format. Unable to convert to JSON.")
 
+            agent_steps = []
+            step_start = time.time()
+
             for output in self.agent.stream({"question": input_data["input"], "conversation": input_data["conversation"]}):
 
                 for key, value in output.items():
-                    # logger.info(f"testing steps {key}: {value}")
-                    LogWriter.info(f"request_id={req_id_cv.get()} executed node {key}")
+                    step_end = time.time()
+                    step_duration = round(step_end - step_start, 3)
+                    agent_steps.append({
+                        "node": key,
+                        "duration_s": step_duration,
+                    })
+                    LogWriter.info(
+                        f"request_id={req_id_cv.get()} executed node {key} ({step_duration}s)"
+                    )
+                    step_start = step_end
+
+            answer = value["answer"]
+            if answer.query_sources is None:
+                answer.query_sources = {}
+            answer.query_sources["agent_steps"] = agent_steps
 
             LogWriter.info(f"request_id={req_id_cv.get()} EXIT question_for_agent")
-            return value["answer"]
+            return answer
         except Exception as e:
             metrics.llm_query_error_total.labels(self.model_name).inc()
             LogWriter.error(f"request_id={req_id_cv.get()} FAILURE question_for_agent")

--- a/graphrag/app/agent/agent.py
+++ b/graphrag/app/agent/agent.py
@@ -146,13 +146,12 @@ class TigerGraphAgent:
                     )
                     step_start = step_end
 
-            answer = value["answer"]
-            if answer.query_sources is None:
-                answer.query_sources = {}
-            answer.query_sources["agent_steps"] = agent_steps
+            if value["answer"].query_sources is None:
+                value["answer"].query_sources = {}
+            value["answer"].query_sources["agent_steps"] = agent_steps
 
             LogWriter.info(f"request_id={req_id_cv.get()} EXIT question_for_agent")
-            return answer
+            return value["answer"]
         except Exception as e:
             metrics.llm_query_error_total.labels(self.model_name).inc()
             LogWriter.error(f"request_id={req_id_cv.get()} FAILURE question_for_agent")

--- a/graphrag/app/agent/agent.py
+++ b/graphrag/app/agent/agent.py
@@ -129,6 +129,13 @@ class TigerGraphAgent:
                 logger.error(f"Failed to serialize input_data to JSON: {e}")
                 raise ValueError("Invalid input data format. Unable to convert to JSON.")
 
+            def _safe_serialize(obj, max_len=3000):
+                try:
+                    s = json.dumps(obj, default=str)
+                except Exception:
+                    s = str(obj)
+                return s[:max_len] if len(s) > max_len else s
+
             agent_steps = []
             step_start = time.time()
             prev_output = input_data["input"]
@@ -138,13 +145,6 @@ class TigerGraphAgent:
                 for key, value in output.items():
                     step_end = time.time()
                     step_duration = round(step_end - step_start, 3)
-
-                    def _safe_serialize(obj, max_len=3000):
-                        try:
-                            s = json.dumps(obj, default=str)
-                        except Exception:
-                            s = str(obj)
-                        return s[:max_len] if len(s) > max_len else s
 
                     agent_steps.append({
                         "node": key,

--- a/graphrag/app/agent/agent.py
+++ b/graphrag/app/agent/agent.py
@@ -129,34 +129,80 @@ class TigerGraphAgent:
                 logger.error(f"Failed to serialize input_data to JSON: {e}")
                 raise ValueError("Invalid input data format. Unable to convert to JSON.")
 
-            def _safe_serialize(obj, max_len=3000):
+            def _safe(obj):
                 try:
-                    s = json.dumps(obj, default=str)
+                    return json.dumps(obj, default=str)
                 except Exception:
-                    s = str(obj)
-                return s[:max_len] if len(s) > max_len else s
+                    return str(obj)
+
+            def _node_output(node, state):
+                """Extract the meaningful output that this node produced."""
+                _LOOKUP_LABELS = {"inquiryai": "db_search", "supportai": "vector_search"}
+                lookup = state.get("lookup_source", "")
+                lookup = _LOOKUP_LABELS.get(lookup, lookup)
+
+                if node == "entry":
+                    return ""
+                elif node == "map_question_to_schema":
+                    return _safe({"schema_mapping": str(state.get("schema_mapping", ""))})
+                elif node == "generate_function":
+                    ctx = state.get("context", {})
+                    return _safe({
+                        "context": ctx if isinstance(ctx, dict) else str(ctx),
+                        "lookup_source": lookup,
+                    })
+                elif node == "generate_cypher":
+                    ctx = state.get("context", {})
+                    return _safe({
+                        "cypher": ctx.get("cypher", "") if isinstance(ctx, dict) else "",
+                        "reasoning": ctx.get("reasoning", "") if isinstance(ctx, dict) else "",
+                        "result": ctx.get("result", "") if isinstance(ctx, dict) else "",
+                        "lookup_source": lookup,
+                    })
+                elif node == "supportai":
+                    ctx = state.get("context", {})
+                    return _safe({
+                        "context": ctx if isinstance(ctx, dict) else str(ctx),
+                        "lookup_source": lookup,
+                    })
+                elif node == "generate_answer":
+                    ans = state.get("answer")
+                    return _safe({
+                        "natural_language_response": getattr(ans, "natural_language_response", "") if ans else "",
+                        "answered_question": getattr(ans, "answered_question", False) if ans else False,
+                        "response_type": getattr(ans, "response_type", "") if ans else "",
+                    })
+                elif node in ("greet", "apologize"):
+                    ans = state.get("answer")
+                    return getattr(ans, "natural_language_response", "") if ans else ""
+                return _safe(state)
 
             agent_steps = []
             step_start = time.time()
-            prev_output = input_data["input"]
+            prev_state = {"question": input_data["input"], "conversation": input_data["conversation"]}
 
             for output in self.agent.stream({"question": input_data["input"], "conversation": input_data["conversation"]}):
 
                 for key, value in output.items():
                     step_end = time.time()
                     step_duration = round(step_end - step_start, 3)
-
                     agent_steps.append({
                         "node": key,
                         "duration_s": step_duration,
-                        "input": _safe_serialize(prev_output),
-                        "output": _safe_serialize(value),
+                        "input": _safe(prev_state),
+                        "output": _node_output(key, value),
                     })
-                    prev_output = value
+                    prev_state = value
                     LogWriter.info(
                         f"request_id={req_id_cv.get()} executed node {key} ({step_duration}s)"
                     )
                     step_start = step_end
+
+            # Backfill entry with routing decision
+            if len(agent_steps) >= 2 and agent_steps[0]["node"] == "entry":
+                next_node = agent_steps[1]["node"]
+                _ROUTE_LABELS = {"supportai": "vector_search", "map_question_to_schema": "db_search", "lookup_history": "history_lookup"}
+                agent_steps[0]["output"] = _safe({"routing_decision": _ROUTE_LABELS.get(next_node, next_node)})
 
             if value["answer"].query_sources is None:
                 value["answer"].query_sources = {}

--- a/graphrag/app/agent/agent.py
+++ b/graphrag/app/agent/agent.py
@@ -131,16 +131,28 @@ class TigerGraphAgent:
 
             agent_steps = []
             step_start = time.time()
+            prev_output = input_data["input"]
 
             for output in self.agent.stream({"question": input_data["input"], "conversation": input_data["conversation"]}):
 
                 for key, value in output.items():
                     step_end = time.time()
                     step_duration = round(step_end - step_start, 3)
+
+                    def _safe_serialize(obj, max_len=3000):
+                        try:
+                            s = json.dumps(obj, default=str)
+                        except Exception:
+                            s = str(obj)
+                        return s[:max_len] if len(s) > max_len else s
+
                     agent_steps.append({
                         "node": key,
                         "duration_s": step_duration,
+                        "input": _safe_serialize(prev_output),
+                        "output": _safe_serialize(value),
                     })
+                    prev_output = value
                     LogWriter.info(
                         f"request_id={req_id_cv.get()} executed node {key} ({step_duration}s)"
                     )

--- a/graphrag/app/routers/ui.py
+++ b/graphrag/app/routers/ui.py
@@ -361,37 +361,16 @@ def add_feedback(
 
 
 @router.get(route_prefix + "/trace/{message_id}")
-def get_trace_log(message_id: str):
+def get_trace_log(
+    message_id: str,
+    creds: Annotated[tuple[list[str], HTTPBasicCredentials], Depends(ui_basic_auth)],
+):
     filepath = os.path.join(TRACE_LOGS_DIR, f"{message_id}.json")
     if not os.path.exists(filepath):
         raise HTTPException(status_code=404, detail="Trace log not found")
     with open(filepath, "r") as f:
         return json.load(f)
 
-
-@router.get(route_prefix + "/traces/{conversation_id}")
-def list_trace_logs(conversation_id: str):
-    if not os.path.isdir(TRACE_LOGS_DIR):
-        return []
-    traces = []
-    for filename in os.listdir(TRACE_LOGS_DIR):
-        if not filename.endswith(".json"):
-            continue
-        filepath = os.path.join(TRACE_LOGS_DIR, filename)
-        try:
-            with open(filepath, "r") as f:
-                data = json.load(f)
-            if data.get("conversation_id") == conversation_id:
-                traces.append({
-                    "message_id": data.get("message_id"),
-                    "user_query": data.get("user_query"),
-                    "response_time": data.get("response_time"),
-                    "timestamp": data.get("timestamp"),
-                })
-        except Exception:
-            continue
-    traces.sort(key=lambda t: t.get("timestamp", 0))
-    return traces
 
 
 @router.post(route_prefix + "/{graphname}/create_graph")
@@ -1130,7 +1109,7 @@ async def graph_query(
             query_sources=resp.query_sources,
         )
         await write_message_to_history(message, auth)
-        _save_trace_log(message.message_id, convo_id, data, resp, elapsed)
+        await asyncio.to_thread(_save_trace_log, message.message_id, convo_id, data, resp, elapsed)
         prev_id = message.message_id
 
         # reply
@@ -1257,7 +1236,7 @@ async def chat(
                 query_sources=resp.query_sources,
             )
             await write_message_to_history(message, usr_auth)
-            _save_trace_log(message.message_id, convo_id, data, resp, elapsed)
+            await asyncio.to_thread(_save_trace_log, message.message_id, convo_id, data, resp, elapsed)
             prev_id = message.message_id
 
             # reply

--- a/graphrag/app/routers/ui.py
+++ b/graphrag/app/routers/ui.py
@@ -70,6 +70,28 @@ from common.py_schemas.schemas import (
 
 logger = logging.getLogger(__name__)
 
+TRACE_LOGS_DIR = os.environ.get("TRACE_LOGS_DIR", "/code/trace_logs")
+
+def _save_trace_log(message_id: str, conversation_id: str, user_query: str, resp: GraphRAGResponse, elapsed: float):
+    try:
+        os.makedirs(TRACE_LOGS_DIR, exist_ok=True)
+        trace_data = {
+            "message_id": message_id,
+            "conversation_id": conversation_id,
+            "user_query": user_query,
+            "response_time": elapsed,
+            "response_type": resp.response_type,
+            "answered_question": resp.answered_question,
+            "query_sources": resp.query_sources,
+            "natural_language_response": resp.natural_language_response,
+            "timestamp": time.time(),
+        }
+        filepath = os.path.join(TRACE_LOGS_DIR, f"{message_id}.json")
+        with open(filepath, "w") as f:
+            json.dump(trace_data, f, default=str)
+    except Exception:
+        logger.warning(f"Failed to save trace log for message {message_id}", exc_info=True)
+
 # Validated graph name path parameter — rejects path traversal characters
 ValidGraphName = Annotated[str, Path(pattern=r"^[A-Za-z_][A-Za-z0-9_]*$")]
 
@@ -336,6 +358,40 @@ def add_feedback(
         raise e
 
     return {"message": "feedback saved", "message_id": message.message_id}
+
+
+@router.get(route_prefix + "/trace/{message_id}")
+def get_trace_log(message_id: str):
+    filepath = os.path.join(TRACE_LOGS_DIR, f"{message_id}.json")
+    if not os.path.exists(filepath):
+        raise HTTPException(status_code=404, detail="Trace log not found")
+    with open(filepath, "r") as f:
+        return json.load(f)
+
+
+@router.get(route_prefix + "/traces/{conversation_id}")
+def list_trace_logs(conversation_id: str):
+    if not os.path.isdir(TRACE_LOGS_DIR):
+        return []
+    traces = []
+    for filename in os.listdir(TRACE_LOGS_DIR):
+        if not filename.endswith(".json"):
+            continue
+        filepath = os.path.join(TRACE_LOGS_DIR, filename)
+        try:
+            with open(filepath, "r") as f:
+                data = json.load(f)
+            if data.get("conversation_id") == conversation_id:
+                traces.append({
+                    "message_id": data.get("message_id"),
+                    "user_query": data.get("user_query"),
+                    "response_time": data.get("response_time"),
+                    "timestamp": data.get("timestamp"),
+                })
+        except Exception:
+            continue
+    traces.sort(key=lambda t: t.get("timestamp", 0))
+    return traces
 
 
 @router.post(route_prefix + "/{graphname}/create_graph")
@@ -1074,6 +1130,7 @@ async def graph_query(
             query_sources=resp.query_sources,
         )
         await write_message_to_history(message, auth)
+        _save_trace_log(message.message_id, convo_id, data, resp, elapsed)
         prev_id = message.message_id
 
         # reply
@@ -1200,6 +1257,7 @@ async def chat(
                 query_sources=resp.query_sources,
             )
             await write_message_to_history(message, usr_auth)
+            _save_trace_log(message.message_id, convo_id, data, resp, elapsed)
             prev_id = message.message_id
 
             # reply

--- a/graphrag/app/routers/ui.py
+++ b/graphrag/app/routers/ui.py
@@ -72,9 +72,24 @@ logger = logging.getLogger(__name__)
 
 TRACE_LOGS_DIR = os.environ.get("TRACE_LOGS_DIR", "/code/trace_logs")
 
+def _cleanup_old_traces(max_age_days: int = 30):
+    """Delete trace log files older than max_age_days."""
+    try:
+        cutoff = time.time() - (max_age_days * 86400)
+        for filename in os.listdir(TRACE_LOGS_DIR):
+            if not filename.endswith(".json"):
+                continue
+            filepath = os.path.join(TRACE_LOGS_DIR, filename)
+            if os.path.getmtime(filepath) < cutoff:
+                os.remove(filepath)
+    except Exception:
+        logger.warning("Failed to clean up old trace logs", exc_info=True)
+
+
 def _save_trace_log(message_id: str, conversation_id: str, user_query: str, resp: GraphRAGResponse, elapsed: float):
     try:
         os.makedirs(TRACE_LOGS_DIR, exist_ok=True)
+        _cleanup_old_traces()
 
         # Strip chunk text from query_sources to keep trace files small.
         # final_retrieval contains the full text of every retrieved chunk.

--- a/graphrag/app/routers/ui.py
+++ b/graphrag/app/routers/ui.py
@@ -75,6 +75,15 @@ TRACE_LOGS_DIR = os.environ.get("TRACE_LOGS_DIR", "/code/trace_logs")
 def _save_trace_log(message_id: str, conversation_id: str, user_query: str, resp: GraphRAGResponse, elapsed: float):
     try:
         os.makedirs(TRACE_LOGS_DIR, exist_ok=True)
+
+        # Strip chunk text from query_sources to keep trace files small.
+        # final_retrieval contains the full text of every retrieved chunk.
+        query_sources = dict(resp.query_sources) if resp.query_sources else {}
+        result = query_sources.get("result")
+        if isinstance(result, dict) and "final_retrieval" in result:
+            result = {k: v for k, v in result.items() if k != "final_retrieval"}
+            query_sources = {**query_sources, "result": result}
+
         trace_data = {
             "message_id": message_id,
             "conversation_id": conversation_id,
@@ -82,7 +91,7 @@ def _save_trace_log(message_id: str, conversation_id: str, user_query: str, resp
             "response_time": elapsed,
             "response_type": resp.response_type,
             "answered_question": resp.answered_question,
-            "query_sources": resp.query_sources,
+            "query_sources": query_sources,
             "natural_language_response": resp.natural_language_response,
             "timestamp": time.time(),
         }


### PR DESCRIPTION
### **User description**
## Trace Logs UI

Adds a **"View Trace"** link on bot responses that opens a detailed Trace Logs page showing:
- Original user query
- Timing overview (total duration, tool execution, LLM thinking)
- All LangGraph agent nodes executed with per-node duration
- Source citations with cited/considered status
- Visual timeline of the execution flow

**Backend**: Instrumented the LangGraph `stream()` loop in `agent.py` to capture each node's name and execution time into `query_sources.agent_steps`.

**Frontend**: New `TraceLogs.tsx` page with tabs (Logs, Tool Calls, Citations, Timeline), wired via "View Trace" link in chat messages.


___

### **PR Type**
Enhancement


___

### **Description**
- Instrument agent to capture step timings

- Add Trace Logs page with tabs

- Pass user query and agent steps

- Add "View Trace" link in chat


___

### Diagram Walkthrough


```mermaid
flowchart LR
  agentPy["Backend agent.py streams nodes"]
  capture["Capture durations as agent_steps"]
  answerAug["Augment answer.query_sources.agent_steps"]
  ws["WebSocket message to UI"]
  attach["Attach userQuery in ActionProvider"]
  viewLink["Chat 'View Trace' button"]
  route["/trace route"]
  tracePage["TraceLogs page (Logs/Tools/Citations/Timeline)"]

  agentPy -- "measure durations" --> capture
  capture -- "attach to answer" --> answerAug
  answerAug -- "send" --> ws
  ws -- "enrich with userQuery" --> attach
  attach -- "render" --> viewLink
  viewLink -- "navigate" --> route
  route -- "display" --> tracePage
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.py</strong><dd><code>Capture and attach agent node timings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

graphrag/app/agent/agent.py

<ul><li>Measure per-node durations during stream<br> <li> Accumulate <code>agent_steps</code> with node and seconds<br> <li> Log executed node with duration<br> <li> Attach <code>agent_steps</code> to <code>answer.query_sources</code></ul>


</details>


  </td>
  <td><a href="https://github.com/tigergraph/graphrag/pull/33/files#diff-21b6ee06c77f665fd7772366a70c1d9861d4c82cfed32bc423ac7e72607f1b19">+19/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ActionProvider.tsx</strong><dd><code>Propagate user query into bot messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

graphrag-ui/src/actions/ActionProvider.tsx

<ul><li>Track last user query via <code>useRef</code><br> <li> Store query on send (default/questions)<br> <li> Attach <code>userQuery</code> to incoming message data<br> <li> Adjust imports to include <code>useRef</code></ul>


</details>


  </td>
  <td><a href="https://github.com/tigergraph/graphrag/pull/33/files#diff-16b0b36230dcfb45e19728a1b279229508bff3de49bbaf794e3c88d3cffe6f51">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CustomChatMessage.tsx</strong><dd><code>Add View Trace action in chat messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

graphrag-ui/src/components/CustomChatMessage.tsx

<ul><li>Add "View Trace" button with icon<br> <li> Navigate to <code>/trace</code> with state payload<br> <li> Show when <code>query_sources</code> present</ul>


</details>


  </td>
  <td><a href="https://github.com/tigergraph/graphrag/pull/33/files#diff-cfff26097e20241baca29ca937bc99de30994552ea521f60b571632c99d837f1">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.tsx</strong><dd><code>Register Trace Logs route</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

graphrag-ui/src/main.tsx

- Import new `TraceLogs` page
- Register protected `/trace` route


</details>


  </td>
  <td><a href="https://github.com/tigergraph/graphrag/pull/33/files#diff-e82a3eb03a96f5d8bc1e29c14b6080b9eb7d437436c438b0664c6cf50e4e8a64">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TraceLogs.tsx</strong><dd><code>Implement Trace Logs page with tabs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

graphrag-ui/src/pages/TraceLogs.tsx

<ul><li>New Trace Logs page and UI<br> <li> Build trace from <code>message.query_sources</code><br> <li> Tabs: Logs, Tool Calls, Citations, Timeline<br> <li> Download trace JSON and copy content</ul>


</details>


  </td>
  <td><a href="https://github.com/tigergraph/graphrag/pull/33/files#diff-2a9285146cff9a154ea772e645cd33d63dd0c045ddaeecfe0168698d95f6c0f7">+697/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

