### PR TITLE
GML-2131: Respect configured TigerGraph ports during UI login

### DIFF
--- a/graphrag/app/routers/ui.py
+++ b/graphrag/app/routers/ui.py
@@ -493,15 +493,25 @@ def auth(usr: str, password: str, conn=None) -> tuple[list[str], TigerGraphConne
         #   * ``__GSQL__secret:<secret>`` → TigerGraph's native secret
         #     convention; pyTigerGraph already understands it when sent
         #     as plain username/password, so no special handling here.
+        connection_kwargs = {
+            "host": db_config["hostname"],
+            "graphname": "",
+        }
+        if db_config.get("gsPort") is not None:
+            connection_kwargs["gsPort"] = db_config["gsPort"]
+        if db_config.get("restppPort") is not None:
+            connection_kwargs["restppPort"] = db_config["restppPort"]
+
         if usr == _UI_TOKEN_SENTINEL:
             conn = TigerGraphConnection(
-                host=db_config["hostname"], graphname="",
+                **connection_kwargs,
                 apiToken=password,
             )
         else:
             conn = TigerGraphConnection(
-                host=db_config["hostname"], graphname="",
-                username=usr, password=password,
+                **connection_kwargs,
+                username=usr,
+                password=password,
             )
 
     try:


### PR DESCRIPTION
### **User description**
### PR Type

Bug Fix

---

### Description

  * Respect configured TigerGraph `gsPort` and `restppPort` during UI login

  * Fix `/ui/ui-login` incorrectly falling back to pyTigerGraph default RESTPP port `9000`

  * Apply the same connection port configuration to both username/password and API-token login paths

  * Prevent valid TigerGraph credentials from being rejected when TigerGraph is exposed on a non-default port such as `14240`

---

### Diagram Walkthrough

    flowchart LR
      browser["GraphRAG UI login"] --> api["/ui/ui-login"]
      api --> auth["auth()"]
      auth --> config["db_config"]
      config --> ports["gsPort / restppPort"]
      ports --> tg["TigerGraphConnection"]
      tg --> graphs["listGraphs() succeeds"]

---

### File Walkthrough

Relevant files

Bug Fix 1 file

`graphrag/app/routers/ui.py`  
`Pass configured TigerGraph gsPort/restppPort into UI login TigerGraphConnection calls`

---

### Validation

  * Reproduced the issue with TigerGraph exposed on port `14240`

  * Confirmed `TigerGraphConnection(..., gsPort=14240, restppPort=14240)` succeeds with the same credentials

  * Confirmed the existing `/ui/ui-login` path fails because it falls back to port `9000`

  * Confirmed `/ui/ui-login` returns `200 OK` after passing configured `gsPort` and `restppPort`


___

### **PR Type**
Bug fix


___

### **Description**
- Pass configured ports to UI login

- Fix non-default TigerGraph port authentication


___

### Diagram Walkthrough


```mermaid
flowchart LR
  login["UI login credentials"] 
  auth["auth() connection setup"]
  config["Configured gsPort/restppPort"]
  tg["TigerGraphConnection"]
  graphs["listGraphs()"]

  login -- "calls" --> auth
  config -- "provides ports" --> auth
  auth -- "creates" --> tg
  tg -- "authenticates via configured ports" --> graphs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ui.py</strong><dd><code>Configure TigerGraph ports for UI authentication</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

graphrag/app/routers/ui.py

<ul><li>Adds <code>gsPort</code> from <code>db_config</code> to UI login connections<br> <li> Adds <code>restppPort</code> from <code>db_config</code> to UI login connections<br> <li> Applies port configuration to token and password login paths</ul>


</details>


  </td>
  <td><a href="https://github.com/tigergraph/graphrag/pull/44/files#diff-6bd0577645f5c331c0503b21762ac99be7a11b0f1dd72d4435a84a02f0d18f62">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

