### PR TITLE
GML-2163-UI-GAP: surface rebuild stage in UI during long ECC phases - add progres…

### DIFF
--- a/ecc/app/graphrag/graph_rag.py
+++ b/ecc/app/graphrag/graph_rag.py
@@ -57,10 +57,9 @@ async def stream_docs(
     Streams the document contents into the docs_chan, over ``ttl_batches``
     partitions (each StreamIds call claims and returns one partition).
 
-    *progress* (optional) is a callable invoked once when document
-    streaming completes — runtime hands the rebuild status forward
-    from "Chunking documents" to "Extracting entities and
-    relationships" at that boundary.
+    *progress* is accepted for API compatibility with callers but is
+    not used here — the UI stage advances after chunk_docs finishes,
+    not when streaming completes.
     """
     logger.info(f"streaming docs ({ttl_batches} batches)")
     n_docs = 0
@@ -87,11 +86,9 @@ async def stream_docs(
     # close the docs chan -- this function is the only sender
     logger.info("closing docs chan")
     docs_chan.close()
-    if progress is not None:
-        try:
-            progress("Extracting entities and relationships")
-        except Exception:
-            pass
+    # Do NOT advance the UI stage here. Streaming finishing does not
+    # mean chunking is done; advancing here used to clear the chunking
+    # progress bar before chunk_docs finished (and before the UI polled).
 
 async def stream_chunks(
     conn: AsyncTigerGraphConnection,
@@ -163,29 +160,80 @@ async def chunk_docs(
     embed_chan: Channel,
     upsert_chan: Channel,
     extract_chan: Channel,
+    progress=None,
+    total_docs: int = 0,
 ):
     """
     Creates and starts one worker for each document
     in the docs channel.
+
+    When *total_docs* is known (unprocessed Document count), reports
+    document-level chunking progress via *progress* so the UI can show
+    a percentage bar.
     """
     logger.info("Chunk Processing Start")
-    doc_tasks = []
     n_docs = 0
+
+    async def _chunk_one(content):
+        nonlocal n_docs
+        await workers.chunk_doc(conn, content, upsert_chan, embed_chan, extract_chan)
+        n_docs += 1
+        if progress is not None and total_docs > 0:
+            pct = min(100, int(100 * n_docs / total_docs))
+            try:
+                progress(
+                    f"Chunking documents ({n_docs}/{total_docs} — {pct}%)",
+                    current=n_docs,
+                    total=total_docs,
+                )
+            except TypeError:
+                try:
+                    progress(f"Chunking documents ({n_docs}/{total_docs} — {pct}%)")
+                except Exception:
+                    pass
+            except Exception:
+                pass
+
     async with asyncio.TaskGroup() as grp:
         while True:
             try:
                 content = await docs_chan.get()
-                n_docs += 1
-                task = grp.create_task(
-                    workers.chunk_doc(conn, content, upsert_chan, embed_chan, extract_chan)
-                )
-                doc_tasks.append(task)
+                grp.create_task(_chunk_one(content))
             except ChannelClosed:
                 break
             except Exception:
                 raise
 
     logger.info(f"Chunk Processing End: {n_docs} document(s) processed")
+
+    # Chunking finished — mark 100% then move stage forward and clear bar.
+    if progress is not None:
+        if total_docs > 0:
+            try:
+                progress(
+                    f"Chunking documents ({n_docs}/{total_docs} — 100%)",
+                    current=total_docs,
+                    total=total_docs,
+                )
+            except TypeError:
+                try:
+                    progress(f"Chunking documents ({n_docs}/{total_docs} — 100%)")
+                except Exception:
+                    pass
+            except Exception:
+                pass
+        try:
+            progress(
+                "Extracting entities and relationships",
+                clear_progress=True,
+            )
+        except TypeError:
+            try:
+                progress("Extracting entities and relationships")
+            except Exception:
+                pass
+        except Exception:
+            pass
 
     logger.info("closing extract_chan")
     await extract_chan.put(None)
@@ -333,7 +381,7 @@ async def load(conn: AsyncTigerGraphConnection):
 
 
 async def embed(
-    embed_chan: Channel, embedding_store: EmbeddingStore, graphname: str, progress=None
+    embed_chan: Channel, embedding_store: EmbeddingStore, graphname: str
 ):
     """
     Creates and starts one worker for each embed job
@@ -366,11 +414,6 @@ async def embed(
                 n_embed += 1
                 if n_embed % 100 == 0:
                     logger.info(f"Embedding Processing: {n_embed} embedded so far")
-                    if progress is not None:
-                        try:
-                            progress(f"Embedding documents ({n_embed} embedded so far)")
-                        except Exception:
-                            pass
             except ChannelClosed:
                 break
             except Exception:
@@ -388,7 +431,6 @@ async def extract(
     extractor: BaseExtractor,
     conn: AsyncTigerGraphConnection,
     num_senders: int,
-    progress=None,
 ):
     """
     Creates and starts one worker for each extract job
@@ -418,11 +460,6 @@ async def extract(
                             logger.info(
                                 f"Entity Extraction: {n_chunks} chunks dispatched"
                             )
-                            if progress is not None:
-                                try:
-                                    progress(f"Extracting entities ({n_chunks} chunks processed)")
-                                except Exception:
-                                    pass
             except ChannelClosed:
                 break
             except Exception:
@@ -547,7 +584,6 @@ async def summarize_communities(
     comm_process_chan: Channel,
     upsert_chan: Channel,
     embed_chan: Channel,
-    progress=None,
 ):
     logger.info("Community summarization started")
     n_comm = 0
@@ -564,11 +600,6 @@ async def summarize_communities(
                     logger.info(
                         f"Community summarization: {n_comm} dispatched"
                     )
-                    if progress is not None:
-                        try:
-                            progress(f"Summarizing communities ({n_comm} done so far)")
-                        except Exception:
-                            pass
             except ChannelClosed:
                 break
             except Exception:
@@ -599,11 +630,21 @@ async def run(graphname: str, conn: AsyncTigerGraphConnection, progress=None):
     where the job is.
     """
 
-    def _report(msg: str) -> None:
+    def _report(msg: str, current=None, total=None, clear_progress=False) -> None:
         if progress is None:
             return
         try:
-            progress(msg)
+            progress(
+                msg,
+                current=current,
+                total=total,
+                clear_progress=clear_progress,
+            )
+        except TypeError:
+            try:
+                progress(msg)
+            except Exception:
+                pass
         except Exception:
             pass
 
@@ -640,20 +681,51 @@ async def run(graphname: str, conn: AsyncTigerGraphConnection, progress=None):
             # remaining producer racing chunk_docs' load_q writes.
             async def new_doc_pipeline():
                 await sc_task
+                # Count unprocessed Documents before StreamIds claims them,
+                # so chunking can report document-level % progress.
+                total_docs = 0
+                try:
+                    count_result = conn.getVertexCount(
+                        "Document", where="epoch_processed=0"
+                    )
+                    if asyncio.iscoroutine(count_result):
+                        count_result = await count_result
+                    total_docs = int(count_result or 0)
+                except Exception as e:
+                    logger.warning(
+                        f"Could not count unprocessed Documents for progress: {e}"
+                    )
+                if total_docs > 0:
+                    _report(
+                        f"Chunking documents (0/{total_docs} — 0%)",
+                        current=0,
+                        total=total_docs,
+                    )
+                    logger.info(
+                        f"Chunking progress denominator: {total_docs} unprocessed Document(s)"
+                    )
                 async with asyncio.TaskGroup() as inner:
                     inner.create_task(
                         stream_docs(conn, docs_chan, 100, progress=progress)
                     )
                     inner.create_task(
-                        chunk_docs(conn, docs_chan, embed_chan, upsert_chan, extract_chan)
+                        chunk_docs(
+                            conn,
+                            docs_chan,
+                            embed_chan,
+                            upsert_chan,
+                            extract_chan,
+                            progress=progress,
+                            total_docs=total_docs,
+                        )
                     )
             grp.create_task(new_doc_pipeline())
 
             grp.create_task(upsert(upsert_chan))
             grp.create_task(load(conn))
-            grp.create_task(embed(embed_chan, embedding_store, graphname, progress))
+            grp.create_task(embed(embed_chan, embedding_store, graphname))
             grp.create_task(
-                extract(extract_chan, upsert_chan, embed_chan, extractor, conn, num_chunk_senders, progress)
+                extract(extract_chan, upsert_chan, embed_chan, extractor, conn, num_chunk_senders)
             )
     logger.info("Join docs_chan")
     await docs_chan.join()
@@ -678,7 +750,7 @@ async def run(graphname: str, conn: AsyncTigerGraphConnection, progress=None):
     # schema edits could still leave queries missing.
     community_start = time.perf_counter()
     if community_detection_switch:
-        _report("Detecting communities")
+        _report("Detecting communities", clear_progress=True)
         await install_queries(COMMUNITY_QUERIES, conn)
         logger.info("Community Processing Start")
 
@@ -704,11 +776,11 @@ async def run(graphname: str, conn: AsyncTigerGraphConnection, progress=None):
             grp.create_task(communities(conn, comm_process_chan))
             # summarize each community
             grp.create_task(
-                summarize_communities(conn, comm_process_chan, upsert_chan, embed_chan, progress)
+                summarize_communities(conn, comm_process_chan, upsert_chan, embed_chan)
             )
             grp.create_task(upsert(upsert_chan))
             grp.create_task(load(conn))
-            grp.create_task(embed(embed_chan, embedding_store, graphname, progress))
+            grp.create_task(embed(embed_chan, embedding_store, graphname))
         logger.info("Join comm_process_chan")
         await comm_process_chan.join()
         logger.info("Join embed_chan")
@@ -738,7 +810,7 @@ async def run(graphname: str, conn: AsyncTigerGraphConnection, progress=None):
                     f"IN_COMMUNITY pair missing on schema"
                 )
             if mirrorable:
-                _report("Updating domain types")
+                _report("Updating domain types", clear_progress=True)
                 await graphrag_mirror_communities(conn, mirrorable)
     community_end = time.perf_counter()
     logger.info("Community Processing End")

--- a/ecc/app/graphrag/graph_rag.py
+++ b/ecc/app/graphrag/graph_rag.py
@@ -333,7 +333,7 @@ async def load(conn: AsyncTigerGraphConnection):
 
 
 async def embed(
-    embed_chan: Channel, embedding_store: EmbeddingStore, graphname: str
+    embed_chan: Channel, embedding_store: EmbeddingStore, graphname: str, progress=None
 ):
     """
     Creates and starts one worker for each embed job
@@ -366,6 +366,11 @@ async def embed(
                 n_embed += 1
                 if n_embed % 100 == 0:
                     logger.info(f"Embedding Processing: {n_embed} embedded so far")
+                    if progress is not None:
+                        try:
+                            progress(f"Embedding documents ({n_embed} embedded so far)")
+                        except Exception:
+                            pass
             except ChannelClosed:
                 break
             except Exception:
@@ -383,6 +388,7 @@ async def extract(
     extractor: BaseExtractor,
     conn: AsyncTigerGraphConnection,
     num_senders: int,
+    progress=None,
 ):
     """
     Creates and starts one worker for each extract job
@@ -412,6 +418,11 @@ async def extract(
                             logger.info(
                                 f"Entity Extraction: {n_chunks} chunks dispatched"
                             )
+                            if progress is not None:
+                                try:
+                                    progress(f"Extracting entities ({n_chunks} chunks processed)")
+                                except Exception:
+                                    pass
             except ChannelClosed:
                 break
             except Exception:
@@ -536,6 +547,7 @@ async def summarize_communities(
     comm_process_chan: Channel,
     upsert_chan: Channel,
     embed_chan: Channel,
+    progress=None,
 ):
     logger.info("Community summarization started")
     n_comm = 0
@@ -552,6 +564,11 @@ async def summarize_communities(
                     logger.info(
                         f"Community summarization: {n_comm} dispatched"
                     )
+                    if progress is not None:
+                        try:
+                            progress(f"Summarizing communities ({n_comm} done so far)")
+                        except Exception:
+                            pass
             except ChannelClosed:
                 break
             except Exception:
@@ -634,9 +651,9 @@ async def run(graphname: str, conn: AsyncTigerGraphConnection, progress=None):
 
             grp.create_task(upsert(upsert_chan))
             grp.create_task(load(conn))
-            grp.create_task(embed(embed_chan, embedding_store, graphname))
+            grp.create_task(embed(embed_chan, embedding_store, graphname, progress))
             grp.create_task(
-                extract(extract_chan, upsert_chan, embed_chan, extractor, conn, num_chunk_senders)
+                extract(extract_chan, upsert_chan, embed_chan, extractor, conn, num_chunk_senders, progress)
             )
     logger.info("Join docs_chan")
     await docs_chan.join()
@@ -687,11 +704,11 @@ async def run(graphname: str, conn: AsyncTigerGraphConnection, progress=None):
             grp.create_task(communities(conn, comm_process_chan))
             # summarize each community
             grp.create_task(
-                summarize_communities(conn, comm_process_chan, upsert_chan, embed_chan)
+                summarize_communities(conn, comm_process_chan, upsert_chan, embed_chan, progress)
             )
             grp.create_task(upsert(upsert_chan))
             grp.create_task(load(conn))
-            grp.create_task(embed(embed_chan, embedding_store, graphname))
+            grp.create_task(embed(embed_chan, embedding_store, graphname, progress))
         logger.info("Join comm_process_chan")
         await comm_process_chan.join()
         logger.info("Join embed_chan")

--- a/ecc/app/main.py
+++ b/ecc/app/main.py
@@ -226,6 +226,9 @@ def rebuild_status(
             "is_running": task_info.get("status") == "running",
             "status": task_info.get("status"),
             "stage": task_info.get("stage"),
+            "progress_current": task_info.get("progress_current"),
+            "progress_total": task_info.get("progress_total"),
+            "progress_pct": task_info.get("progress_pct"),
             "started_at": task_info.get("started_at"),
             "completed_at": task_info.get("completed_at"),
             "failed_at": task_info.get("failed_at"),
@@ -240,14 +243,33 @@ def rebuild_status(
     }
 
 
-def _set_stage(task_key: str, msg: str) -> None:
+def _set_stage(
+    task_key: str,
+    msg: str,
+    current=None,
+    total=None,
+    clear_progress: bool = False,
+) -> None:
     """Update the human-readable stage label for an in-flight task.
-    Pulled out so individual stage transitions don't have to know
-    about the ``running_tasks`` schema.
+
+    Optional *current*/*total* populate a progress bar. Progress fields
+    are left unchanged unless new values are provided or
+    *clear_progress* is True — otherwise a later stage string (e.g.
+    from stream_docs finishing early) would wipe the chunking bar
+    before the UI can poll it.
     """
     info = running_tasks.get(task_key)
-    if info is not None:
-        info["stage"] = msg
+    if info is None:
+        return
+    info["stage"] = msg
+    if current is not None and total is not None and total > 0:
+        info["progress_current"] = int(current)
+        info["progress_total"] = int(total)
+        info["progress_pct"] = min(100, int(100 * current / total))
+    elif clear_progress:
+        info.pop("progress_current", None)
+        info.pop("progress_total", None)
+        info.pop("progress_pct", None)
 
 
 async def run_with_tracking(task_key: str, run_func, graphname: str, conn):
@@ -304,7 +326,15 @@ async def run_with_tracking(task_key: str, run_func, graphname: str, conn):
         # ``run_func`` may ignore the kwarg (the supportai legacy path
         # does); the call falls back to the no-progress signature on
         # ``TypeError``.
-        progress_cb = lambda msg: _set_stage(task_key, msg)
+        def progress_cb(msg, current=None, total=None, clear_progress=False):
+            _set_stage(
+                task_key,
+                msg,
+                current=current,
+                total=total,
+                clear_progress=clear_progress,
+            )
+
         try:
             await run_func(graphname, conn, progress=progress_cb)
         except TypeError:

--- a/graphrag-ui/src/pages/setup/KGAdmin.tsx
+++ b/graphrag-ui/src/pages/setup/KGAdmin.tsx
@@ -234,6 +234,7 @@ const KGAdmin = () => {
     if (!open) {
       setRefreshMessage("");
       setPollingActive(false);
+      setRebuildProgress(null);
     }
   };
 
@@ -471,6 +472,12 @@ const KGAdmin = () => {
   const isRebuildRunningRef = useRef(false);
   const [isCheckingStatus, setIsCheckingStatus] = useState(false);
   const [pollingActive, setPollingActive] = useState(false);
+  // Document-level chunking progress from ECC rebuild_status (optional).
+  const [rebuildProgress, setRebuildProgress] = useState<{
+    pct: number;
+    current: number;
+    total: number;
+  } | null>(null);
 
   // Load available graphs. First seed from sessionStorage so the
   // dropdown shows something immediately, then refresh from
@@ -1124,20 +1131,43 @@ const KGAdmin = () => {
           setRefreshMessage(
             `⚠️ A rebuild is already in progress for "${graphName}" (started at ${startTime})${stage}. Please wait for it to complete.`
           );
+          if (
+            typeof statusData.progress_pct === "number" &&
+            typeof statusData.progress_total === "number" &&
+            statusData.progress_total > 0
+          ) {
+            setRebuildProgress({
+              pct: statusData.progress_pct,
+              current: statusData.progress_current ?? 0,
+              total: statusData.progress_total,
+            });
+          } else if (
+            !(typeof statusData.stage === "string" &&
+              statusData.stage.includes("Chunking documents"))
+          ) {
+            // Keep last chunking bar if a poll lands between updates;
+            // clear only once we've left the chunking stage.
+            setRebuildProgress(null);
+          }
         } else if (wasRunning && statusData.status === "completed") {
           setRefreshMessage(`✅ Rebuild completed successfully for "${graphName}".`);
           setPollingActive(false);
+          setRebuildProgress(null);
         } else if (statusData.status === "failed") {
           setRefreshMessage(`❌ Previous rebuild failed: ${statusData.error || "Unknown error"}`);
           setPollingActive(false);
+          setRebuildProgress(null);
         } else if (statusData.status === "error") {
           setRefreshMessage(`❌ Failed to check rebuild status: ${statusData.error || "Unknown error"}`);
           setPollingActive(false);
+          setRebuildProgress(null);
         } else if (statusData.status === "unknown") {
           setRefreshMessage(`⚠️ ECC service returned unknown status. It may be unavailable.`);
           setPollingActive(false);
+          setRebuildProgress(null);
         } else {
           setRefreshMessage("");
+          setRebuildProgress(null);
         }
       } else {
         setRefreshMessage(`❌ Failed to check rebuild status (HTTP ${statusResponse.status}).`);
@@ -2671,6 +2701,23 @@ const KGAdmin = () => {
                     : "bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300"
                 }`}>
                   {refreshMessage}
+                </div>
+              )}
+
+              {isRebuildRunning && rebuildProgress && (
+                <div className="space-y-1">
+                  <div className="flex justify-between text-xs text-gray-600 dark:text-[#D9D9D9]">
+                    <span>Chunking documents</span>
+                    <span>
+                      {rebuildProgress.current}/{rebuildProgress.total} ({rebuildProgress.pct}%)
+                    </span>
+                  </div>
+                  <div className="h-2 w-full rounded-full bg-gray-200 dark:bg-[#3D3D3D] overflow-hidden">
+                    <div
+                      className="h-full rounded-full bg-tigerOrange transition-all duration-300"
+                      style={{ width: `${Math.min(100, Math.max(0, rebuildProgress.pct))}%` }}
+                    />
+                  </div>
                 </div>
               )}
             </div>

--- a/graphrag/app/routers/ui.py
+++ b/graphrag/app/routers/ui.py
@@ -2307,6 +2307,10 @@ async def forceupdate(
             import traceback
             LogWriter.error(traceback.format_exc())
         finally:
+            # Always drop cached status when monitoring ends (success,
+            # timeout, or unexpected failure) so timeout fallbacks do
+            # not keep reporting a stale rebuild as active.
+            _last_ecc_status_cache.pop(graphname, None)
             # Release lock only after ALL stages complete (or timeout/error)
             release_rebuild_lock(graphname)
             LogWriter.info(f"Released global rebuild lock for {graphname}")
@@ -2361,7 +2365,7 @@ def get_rebuild_status(
             **cached,
             "graphname": graphname,
             "is_running": True,
-            "status": "unknown",
+            "status": cached.get("status", "unknown"),
             "error": "ECC is busy processing, status check timed out. Rebuild likely still in progress."
         }
     except Exception as e:

--- a/graphrag/app/routers/ui.py
+++ b/graphrag/app/routers/ui.py
@@ -62,6 +62,10 @@ from common.logs.logwriter import LogWriter
 from common.metrics.prometheus_metrics import metrics as pmetrics
 from common.metrics.tg_proxy import TigerGraphConnectionProxy
 from common.utils.graph_locks import acquire_graph_lock, release_graph_lock, acquire_rebuild_lock, release_rebuild_lock, get_rebuilding_graph, get_current_operation
+
+# Cache the last successful ECC status response per graph so the UI
+# still sees started_at and stage when ECC is too busy to respond.
+_last_ecc_status_cache: dict = {}
 from supportai import supportai
 from common.py_schemas.schemas import (
     AgentProgess,
@@ -2258,7 +2262,7 @@ async def forceupdate(
             elapsed = 0
             
             while elapsed < max_wait_time:
-                await asyncio.sleep(poll_interval)  # Non-blocking sleep
+                await asyncio.sleep(poll_interval)
                 elapsed += poll_interval
                 
                 try:
@@ -2272,6 +2276,11 @@ async def forceupdate(
                         status_data = status_response.json()
                         is_running = status_data.get("is_running", False)
                         status = status_data.get("status", "unknown")
+
+                        # Cache last known good response so the UI endpoint
+                        # can fall back to it when ECC is too busy to respond.
+                        if is_running and status_data.get("started_at"):
+                            _last_ecc_status_cache[graphname] = status_data
                         
                         # Log every minute to avoid spam
                         if elapsed % 60 == 0:
@@ -2280,6 +2289,7 @@ async def forceupdate(
                         # Check if ALL stages are complete
                         if not is_running and status in ["completed", "failed", "idle"]:
                             LogWriter.info(f"ECC rebuild finished for {graphname} with status: {status} after {elapsed}s")
+                            _last_ecc_status_cache.pop(graphname, None)
                             break
                     else:
                         LogWriter.warning(f"ECC status check returned {status_response.status_code} for {graphname}")
@@ -2290,6 +2300,7 @@ async def forceupdate(
             
             if elapsed >= max_wait_time:
                 LogWriter.error(f"ECC rebuild monitoring timed out for {graphname} after {max_wait_time}s")
+                _last_ecc_status_cache.pop(graphname, None)
                 
         except Exception as e:
             LogWriter.error(f"Error during ECC rebuild monitoring for {graphname}: {e}")
@@ -2342,9 +2353,12 @@ def get_rebuild_status(
                 "error": f"ECC service returned status {response.status_code}"
             }
     except httpx.TimeoutException as e:
-        # ECC is busy (heavy processing) - assume rebuild is still running
+        # ECC is busy (heavy processing) - assume rebuild is still running.
+        # Return the last cached status so the UI keeps started_at and stage.
         LogWriter.warning(f"ECC status check timed out (ECC may be busy): {str(e)}")
+        cached = _last_ecc_status_cache.get(graphname, {})
         return {
+            **cached,
             "graphname": graphname,
             "is_running": True,
             "status": "unknown",


### PR DESCRIPTION
### **User description**
callbacks to embed, extract, summarize_communities; cache last ECC status to fix unknown time on timeout


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Surface long-running rebuild progress

- Preserve ECC status during timeouts

- Propagate progress callbacks across phases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  ecc["ECC rebuild phases"]
  callbacks["Progress callbacks"]
  ui["UI rebuild status"]
  cache["Last status cache"]
  timeout["Timeout fallback"]

  ecc -- "emits updates" --> callbacks
  callbacks -- "updates stage text" --> ui
  ui -- "stores running status" --> cache
  timeout -- "uses cached stage" --> ui
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>graph_rag.py</strong><dd><code>Add rebuild progress callbacks to GraphRAG phases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ecc/app/graphrag/graph_rag.py

<ul><li>Adds optional <code>progress</code> callbacks to <code>embed</code>.<br> <li> Adds optional <code>progress</code> callbacks to <code>extract</code>.<br> <li> Adds optional <code>progress</code> callbacks to <code>summarize_communities</code>.<br> <li> Passes progress callbacks through rebuild task creation.</ul>


</details>


  </td>
  <td><a href="https://github.com/tigergraph/graphrag/pull/47/files#diff-55a1e5b20c75c4a71f03a1541658d1a4de6567501d51550a1464f49901cb626a">+22/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ui.py</strong><dd><code>Cache ECC rebuild status for timeout fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

graphrag/app/routers/ui.py

<ul><li>Adds <code>_last_ecc_status_cache</code> per graph.<br> <li> Caches successful running ECC status responses.<br> <li> Clears cached status on completion or timeout.<br> <li> Returns cached stage data when status polling times out.</ul>


</details>


  </td>
  <td><a href="https://github.com/tigergraph/graphrag/pull/47/files#diff-6bd0577645f5c331c0503b21762ac99be7a11b0f1dd72d4435a84a02f0d18f62">+16/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

