### PR TITLE
GML-2164 Fix incorrect OpenAI label in GenAI and Groq instantiation logs

### DIFF
--- a/common/llm_services/google_genai_service.py
+++ b/common/llm_services/google_genai_service.py
@@ -41,5 +41,5 @@ class GoogleGenAI(LLM_Model):
         )
         self.prompt_path = config["prompt_path"]
         LogWriter.info(
-            f"request_id={req_id_cv.get()} instantiated OpenAI model_name={model_name}"
+            f"request_id={req_id_cv.get()} instantiated GoogleGenAI model_name={model_name}"
         )

--- a/common/llm_services/groq_llm_service.py
+++ b/common/llm_services/groq_llm_service.py
@@ -20,5 +20,5 @@ class Groq(LLM_Model):
         self.llm = ChatGroq(temperature=0, model_name=model_name)
         self.prompt_path = config["prompt_path"]
         LogWriter.info(
-            f"request_id={req_id_cv.get()} instantiated OpenAI model_name={model_name}"
+            f"request_id={req_id_cv.get()} instantiated Groq model_name={model_name}"
         )


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Correct Google GenAI instantiation log label

- Correct Groq instantiation log label


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LLM service initialization"] -- "logs provider name" --> B["Accurate GoogleGenAI and Groq labels"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>google_genai_service.py</strong><dd><code>Correct Google GenAI log provider label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/llm_services/google_genai_service.py

<ul><li>Replaces incorrect <code>OpenAI</code> log label.<br> <li> Logs <code>GoogleGenAI</code> during model instantiation.</ul>


</details>


  </td>
  <td><a href="https://github.com/tigergraph/graphrag/pull/48/files#diff-d172f3e0a9fdbd0b74447b05da9ead056adb33bb8ae3ff02d69d39e0ab1a3d9e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>groq_llm_service.py</strong><dd><code>Correct Groq log provider label</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

common/llm_services/groq_llm_service.py

<ul><li>Replaces incorrect <code>OpenAI</code> log label.<br> <li> Logs <code>Groq</code> during model instantiation.</ul>


</details>


  </td>
  <td><a href="https://github.com/tigergraph/graphrag/pull/48/files#diff-c6e90df25328433fbf3d2f533b2ed4b5d42eeb7ba0bb88b545602e464ab08a9a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

