### PR TITLE
GML-2083: guard check_embedding_rebuilt against an unbound response during rebuild

### DIFF
--- a/ecc/app/graphrag/util.py
+++ b/ecc/app/graphrag/util.py
@@ -657,11 +657,20 @@ async def check_embedding_rebuilt(conn, v_type: str):
                 }
             )
     except Exception as e:
-        logger.error(f"Check embedding rebuilt err:\n{e}")
+        logger.error(
+            f"Check embedding rebuilt err: {e!r}\n{traceback.format_exc()}"
+        )
+        return False
 
-    res = resp[0]["all_have_embedding"]
+    try:
+        res = resp[0]["all_have_embedding"]
+    except (IndexError, KeyError, TypeError) as e:
+        logger.error(
+            f"Check embedding rebuilt unexpected response {resp!r}: {e!r}"
+        )
+        return False
+
     logger.info(resp)
-
     return res
 
 


### PR DESCRIPTION
### **User description**
Return False and log full traceback when communities_have_desc (or embedding check) fails so the wait loop retries instead of crashing the rebuild TaskGroup.


___

### **PR Type**
Bug fix


___

### **Description**
- Return false after polling failures

- Validate polling responses before indexing

- Log tracebacks for diagnostics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Polling query"] -- "exception or malformed response" --> B["Log detailed error"]
  B -- "return False" --> C["Wait loop retries"]
  C -- "avoids crash" --> D["Rebuild continues safely"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>util.py</strong><dd><code>Harden rebuild polling error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ecc/app/graphrag/util.py

<ul><li>Adds <code>False</code> returns after <code>communities_have_desc</code> query exceptions.<br> <li> Adds <code>False</code> returns after <code>vertices_have_embedding</code> query exceptions.<br> <li> Validates response shape before reading <code>all_have_desc</code> or <br><code>all_have_embedding</code>.<br> <li> Logs full tracebacks and unexpected response payloads.</ul>


</details>


  </td>
  <td><a href="https://github.com/tigergraph/graphrag/pull/49/files#diff-6236f9146192c6334b6e11faf3bc998057eb7011469bb23c7f30de117bf8da87">+24/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

